### PR TITLE
Enable ./gradlew install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ gradle-app.setting
 *#
 ~*
 pom.xml
+/bin/
+.project
+.classpath
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'maven'
 
+group = 'com.rabbitmq'
 version = '1.0.0-beta4-SNAPSHOT'
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'hop'
-
+rootProject.name = 'http-client'


### PR DESCRIPTION
- Change project id to http-client
- Add group property
    
Allows installation to `mavenLocal()` during development.
