### PR TITLE
Fix for getChannel()

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -62,6 +62,7 @@ import org.springframework.web.util.UriUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.rabbitmq.http.client.domain.AlivenessTestResult;
 import com.rabbitmq.http.client.domain.BindingInfo;
 import com.rabbitmq.http.client.domain.ChannelInfo;
@@ -795,7 +796,8 @@ public class Client {
     List<HttpMessageConverter<?>> xs = new ArrayList<HttpMessageConverter<?>>();
     final Jackson2ObjectMapperBuilder bldr = Jackson2ObjectMapperBuilder
         .json()
-        .serializationInclusion(JsonInclude.Include.NON_NULL);
+        .serializationInclusion(JsonInclude.Include.NON_NULL)
+        .featuresToEnable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
     xs.add(new MappingJackson2HttpMessageConverter(bldr.build()));
     return xs;
   }

--- a/src/main/java/com/rabbitmq/http/client/domain/ChannelDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ChannelDetails.java
@@ -68,4 +68,15 @@ public class ChannelDetails {
   public void setPeerPort(int peerPort) {
     this.peerPort = peerPort;
   }
+  
+  @Override
+  public String toString() {
+    return "ChannelDetails{" +
+        "connectionName='" + connectionName + '\'' +
+        ", name='" + name + '\'' +
+        ", number=" + number +
+        ", peerHost='" + peerHost + '\'' +
+        ", peerPort=" + peerPort +
+        '}';
+  }
 }

--- a/src/main/java/com/rabbitmq/http/client/domain/ChannelInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ChannelInfo.java
@@ -215,4 +215,12 @@ public class ChannelInfo {
   public void setMessageStats(MessageStats messageStats) {
     this.messageStats = messageStats;
   }
+  
+  public List<ConsumerDetails> getConsumerDetails() {
+      return consumerDetails;
+  }
+  
+  public void setConsumerDetails(List<ConsumerDetails> consumerDetails) {
+      this.consumerDetails = consumerDetails;
+    }
 }

--- a/src/main/java/com/rabbitmq/http/client/domain/ConsumerDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ConsumerDetails.java
@@ -18,9 +18,12 @@ package com.rabbitmq.http.client.domain;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @SuppressWarnings("unused")
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class ConsumerDetails {
   @JsonProperty("consumer_tag")
   private String consumerTag;
@@ -30,6 +33,7 @@ public class ConsumerDetails {
   private ChannelDetails channelDetails;
   private boolean exclusive;
   private Map<String, Object> arguments;
+  @JsonProperty("queue")
   private QueueDetails queueDetails;
 
   public String getConsumerTag() {


### PR DESCRIPTION
getChannel by channel name is blowing up with a Jackson deserialization error when consumer "arguments" (Map<String, Object>) is returned as an empty array. This change tells jackson to default the Map<String,Object> to null in that case. When the consumer has arguments, it works as intended.