### PR TITLE
Remove code that sets an extra "Content-Type" header

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -844,7 +844,6 @@ public class Client {
     // configure HttpClientBuilder essentials
     final HttpClientBuilder bldr = HttpClientBuilder.create().
         setDefaultCredentialsProvider(getCredentialsProvider(url, theUser, thePassword));
-    bldr.setDefaultHeaders(Arrays.asList(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json")));
     if (sslConnectionSocketFactory != null) {
       bldr.setSSLSocketFactory(sslConnectionSocketFactory);
     }


### PR DESCRIPTION
Discovered while testing PT story #151681379.

Prior to this change, two `Content-Type:` headers are sent to the server (observed via Wireshark), which gets parsed by Cowboy into this:

```
<<"content-type">> => <<"application/json;charset=UTF-8, application/json">>
```

then, the above is rejected as it is in an invalid format.

Removing the `setDefaultHeaders` call changes the above to this:

```
<<"content-type">> => <<"application/json;charset=UTF-8">>
```

which is valid.

I'm not sure if [this call](https://github.com/rabbitmq/hop/blob/master/src/main/java/com/rabbitmq/http/client/ReactiveClient.java#L125) needs to be removed as well.

Related to ninenines/cowboy#1229