### PR TITLE
Fix import of client

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ using a single class, `Client`, which needs an API endpoint and
 a pair of credentials to be instantiated:
 
 ``` java
-import com.rabbitmq.http.Client;
+import com.rabbitmq.http.client.Client;
 
 Client c = new Client("http://127.0.0.1:15672/api/", "guest", "guest");
 ```


### PR DESCRIPTION
Since the Client is located in the following package, I wonder if the import shouldn't be like in this PR.

See also
https://github.com/rabbitmq/hop/blob/master/src/main/java/com/rabbitmq/http/client/Client.java#L17

At least I was not able to import it like stated in the usage guide. However I'm also happy to learn, why it should work like that. Thanks

Cheers