### PR TITLE
Fix incorrect message_stats object

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
@@ -121,7 +121,7 @@ public class QueueInfo {
   @JsonProperty("messages")
   private long totalMessages;
   @JsonProperty("message_stats")
-  private RateDetails messageStats;
+  private MessageStats messageStats;
   @JsonProperty("messages_persistent")
   private long totalPersistentMessages;
   @JsonProperty("messages_ram")
@@ -326,11 +326,11 @@ public class QueueInfo {
     this.totalMessages = totalMessages;
   }
 
-  public RateDetails getMessageStats() {
+  public MessageStats getMessageStats() {
     return messageStats;
   }
 
-  public void setMessageStats(RateDetails messageStats) {
+  public void setMessageStats(MessageStats messageStats) {
     this.messageStats = messageStats;
   }
 


### PR DESCRIPTION
The queue info message stats deserializes into the incorrect object. It should be a MessageStats object

Here is an example of the structure

```
"message_stats": {
    "ack": 0,
    "ack_details": {
      "rate": 0.0
    },
    "deliver": 0,
    "deliver_details": {
      "rate": 0.0
    },
    "deliver_get": 0,
    "deliver_get_details": {
      "rate": 0.0
    },
    "publish": 0,
    "publish_details": {
      "rate": 0.0
    },
    "redeliver": 0,
    "redeliver_details": {
      "rate": 0.0
    }
  }
```