### PR TITLE
Throw an exception early if Shovel publish properties are blank

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -766,6 +766,10 @@ public class Client {
    * @param info Shovel info. 
    */
   public void declareShovel(String vhost, ShovelInfo info) {
+    Map<String, Object> props = info.getDetails().getPublishProperties();
+    if(props != null && props.isEmpty()) {
+      throw new IllegalArgumentException("Shovel publish properties must be a non-empty map or null");
+    }
     final URI uri = uriWithPath("./parameters/shovel/" + encodePathSegment(vhost) + "/" + encodePathSegment(info.getName()));
     this.rt.put(uri, info);
   }

--- a/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
+++ b/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
@@ -518,6 +518,10 @@ public class ReactorNettyClient {
     }
 
     public Mono<HttpResponse> declareShovel(String vhost, ShovelInfo info) {
+        Map<String, Object> props = info.getDetails().getPublishProperties();
+        if(props != null && props.isEmpty()) {
+            throw new IllegalArgumentException("Shovel publish properties must be a non-empty map or null");
+        }
         return doPut(info, "parameters", "shovel", enc(vhost), enc(info.getName()));
     }
 


### PR DESCRIPTION
See #138, #139, rabbitmq/rabbitmq-shovel#46 for background.

Closes #139.