### PR TITLE
fix[143] Support for all dynamic shovel properties

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/domain/ShovelDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ShovelDetails.java
@@ -33,6 +33,10 @@ public class ShovelDetails {
 	private String sourceExchangeKey;
 	@JsonProperty("src-queue")
 	private String sourceQueue;
+	@JsonProperty("src-prefetch-count")
+	private Long sourcePrefetchCount;
+	@JsonProperty("src-delete-after")
+	private String sourceDeleteAfter;
 
 	@JsonProperty("dest-uri")
 	private String destinationURI;
@@ -42,6 +46,8 @@ public class ShovelDetails {
 	private String destinationExchangeKey;
 	@JsonProperty("dest-queue")
 	private String destinationQueue;
+	@JsonProperty("dest-add-timestamp-header")
+	private Boolean destinationAddTimestampHeader;
 
 	@JsonProperty("reconnect-delay")
 	private long reconnectDelay;
@@ -162,12 +168,48 @@ public class ShovelDetails {
 		this.publishProperties = publishProperties;
 	}
 
+	public Long getSourcePrefetchCount() {
+		return sourcePrefetchCount;
+	}
+
+	public void setSourcePrefetchCount(Long sourcePrefetchCount) {
+		this.sourcePrefetchCount = sourcePrefetchCount;
+	}
+
+	public String getSourceDeleteAfter() {
+		return sourceDeleteAfter;
+	}
+
+	public void setSourceDeleteAfter(String sourceDeleteAfter) {
+		this.sourceDeleteAfter = sourceDeleteAfter;
+	}
+
+	public Boolean isDestinationAddTimestampHeader() {
+		return destinationAddTimestampHeader;
+	}
+
+	public void setDestinationAddTimestampHeader(Boolean destinationAddTimestampHeader) {
+		this.destinationAddTimestampHeader = destinationAddTimestampHeader;
+	}
+
 	@Override
 	public String toString() {
-		return "ShovelDetails{" + "sourceURI=" + sourceURI + ", sourceExchange=" + sourceExchange + "sourceExchangeKey=" + sourceExchangeKey 
-				+ ", sourceQueue=" + sourceQueue + ", destinationURI=" + destinationURI + ", destinationExchange='" + destinationExchange 
-				+ ", destinationExchangeKey='" + destinationExchangeKey + '\''  + ", destinationQueue='" + destinationQueue + '\'' 
-				+ ", reconnectDelay='" + reconnectDelay + '\'' + ", addForwardHeaders='" + addForwardHeaders + '\'' + ", ackMode='" + ackMode + '\''
-				+ ", publishProperties='" + publishProperties + '}';
+		return "ShovelDetails{" +
+				"sourceURI='" + sourceURI + '\'' +
+				", sourceExchange='" + sourceExchange + '\'' +
+				", sourceExchangeKey='" + sourceExchangeKey + '\'' +
+				", sourceQueue='" + sourceQueue + '\'' +
+				", sourcePrefetchCount='" + sourcePrefetchCount + '\'' +
+				", sourceDeleteAfter='" + sourceDeleteAfter + '\'' +
+				", destinationURI='" + destinationURI + '\'' +
+				", destinationExchange='" + destinationExchange + '\'' +
+				", destinationExchangeKey='" + destinationExchangeKey + '\'' +
+				", destinationQueue='" + destinationQueue + '\'' +
+				", destinationAddTimestampHeader=" + destinationAddTimestampHeader +
+				", reconnectDelay=" + reconnectDelay +
+				", addForwardHeaders=" + addForwardHeaders +
+				", ackMode='" + ackMode + '\'' +
+				", publishProperties=" + publishProperties +
+				'}';
 	}
 }


### PR DESCRIPTION
All dynamic Shovel properties are now supported.
Legacy properties (publish-properties, add-forward-headers) kept they are.

Default values are not decided here, better to be decided on the server-side.