### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,10 +48,10 @@ ext {
   linkScmConnection    = 'https://github.com/rabbitmq/hop.git'
   linkScmDevConnection = 'git@github.com:rabbitmq/hop.git'
 
-  javadocLinks = ["http://docs.oracle.com/javase/7/docs/api/",
-                  "http://docs.oracle.com/javaee/6/api/",
-                  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/",
-                  "http://projectreactor.io/docs/core/release/api/",
+  javadocLinks = ["https://docs.oracle.com/javase/7/docs/api/",
+                  "https://docs.oracle.com/javaee/6/api/",
+                  "https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/",
+                  "https://projectreactor.io/docs/core/release/api/",
                   "https://fasterxml.github.io/jackson-databind/javadoc/2.9/"] as String[]
 }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javaee/6/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/6/api/ ([https](https://docs.oracle.com/javaee/6/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://projectreactor.io/docs/core/release/api/ with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/ ([https](https://projectreactor.io/docs/core/release/api/) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/) result 200).