### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and you should use Langohr instead.
 
 ## Reactive
 
-As of HOP 2.1.0, a new reactive, non-blocking IO client based on [Reactor Netty](http://projectreactor.io/) is available. Note
+As of HOP 2.1.0, a new reactive, non-blocking IO client based on [Reactor Netty](https://projectreactor.io/) is available. Note
 the original blocking IO client remains available.
 
 ## Project Maturity
@@ -32,7 +32,7 @@ This section will be updated as the project matures.
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.rabbitmq/http-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.rabbitmq/http-client)
 
-Project artifacts are available from Maven Central and [repo.spring.io](http://repo.spring.io).
+Project artifacts are available from Maven Central and [repo.spring.io](https://repo.spring.io).
 
 #### Maven
 

--- a/sanity-check.groovy
+++ b/sanity-check.groovy
@@ -1,4 +1,4 @@
-@GrabResolver(name = 'spring-staging', root = 'http://repo.spring.io/libs-staging-local/')
+@GrabResolver(name = 'spring-staging', root = 'https://repo.spring.io/libs-staging-local/')
 @Grab(group = 'com.rabbitmq', module = 'http-client', version = "${version}")
 @Grab(group = 'org.springframework', module = 'spring-web', version = "5.1.3.RELEASE")
 @Grab(group = 'org.apache.httpcomponents', module = 'httpclient', version = "4.5.6")

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,7 +4,7 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:

--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -196,7 +196,7 @@ public class Client {
 
   /**
    * Construct an instance with the provided url and credentials.
-   * @param url the url e.g. "http://guest:guest@localhost:15672/api/".
+   * @param url the url e.g. "https://guest:guest@localhost:15672/api/".
    * @throws MalformedURLException for a badly formed URL.
    * @throws URISyntaxException for a badly formed URL.
    */
@@ -209,7 +209,7 @@ public class Client {
 
   /**
    * Construct an instance with the provided url and credentials.
-   * @param url the url e.g. "http://guest:guest@localhost:15672/api/".
+   * @param url the url e.g. "https://guest:guest@localhost:15672/api/".
    * @throws MalformedURLException for a badly formed URL.
    * @throws URISyntaxException for a badly formed URL.
    */

--- a/src/main/java/com/rabbitmq/http/client/Utils.java
+++ b/src/main/java/com/rabbitmq/http/client/Utils.java
@@ -57,7 +57,7 @@ class Utils {
      * Unreserved characters, i.e. alphanumeric, plus: {@code _ - ! . ~ ' ( ) *}
      * <p>
      *  This list is the same as the {@code unreserved} list in
-     *  <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
+     *  <a href="https://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
      */
     private static final BitSet UNRESERVED   = new BitSet(256);
     /**
@@ -80,9 +80,9 @@ class Utils {
      * Reserved characters, i.e. {@code ;/?:@&=+$,[]}
      * <p>
      *  This list is the same as the {@code reserved} list in
-     *  <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
+     *  <a href="https://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
      *  as augmented by
-     *  <a href="http://www.ietf.org/rfc/rfc2732.txt">RFC 2732</a>
+     *  <a href="https://www.ietf.org/rfc/rfc2732.txt">RFC 2732</a>
      */
     private static final BitSet RESERVED     = new BitSet(256);
 

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -140,7 +140,7 @@ class ClientSpec extends Specification {
 
   def "GET /api/nodes with credentials in the URL"() {
     when: "credentials are provided in the URL"
-    final client = new Client("http://guest:guest@127.0.0.1:15672/api/")
+    final client = new Client("https://guest:guest@127.0.0.1:15672/api/")
 
     and: "retrieves a list of cluster nodes"
     final res = client.getNodes()
@@ -1796,7 +1796,7 @@ class ClientSpec extends Specification {
   }
 
   /**
-   * http://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
+   * https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
    *
    */
   static Integer compareVersions(String str1, String str2) {

--- a/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
@@ -83,7 +83,7 @@ class ReactorNettyClientSpec extends Specification {
 
     protected static ReactorNettyClient newLocalhostNodeClient(ReactorNettyClientOptions options) {
         new ReactorNettyClient(
-                String.format("http://%s:%s@127.0.0.1:15672/api", DEFAULT_USERNAME, DEFAULT_PASSWORD), options
+                String.format("https://%s:%s@127.0.0.1:15672/api", DEFAULT_USERNAME, DEFAULT_PASSWORD), options
         )
     }
 
@@ -1883,7 +1883,7 @@ class ReactorNettyClientSpec extends Specification {
     }
 
     /**
-     * http://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
+     * https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
      *
      */
     static Integer compareVersions(String str1, String str2) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://clojurerabbitmq.info (200) with 1 occurrences could not be migrated:  
   ([https](https://clojurerabbitmq.info) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://%s:%s@127.0.0.1:15672/api (UnknownHostException) with 1 occurrences migrated to:  
  https://%s:%s@127.0.0.1:15672/api ([https](https://%s:%s@127.0.0.1:15672/api) result UnknownHostException).
* http://guest:guest@127.0.0.1:15672/api/ (UnknownHostException) with 1 occurrences migrated to:  
  https://guest:guest@127.0.0.1:15672/api/ ([https](https://guest:guest@127.0.0.1:15672/api/) result UnknownHostException).
* http://guest:guest@localhost:15672/api/ (UnknownHostException) with 2 occurrences migrated to:  
  https://guest:guest@localhost:15672/api/ ([https](https://guest:guest@localhost:15672/api/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://projectreactor.io/ with 1 occurrences migrated to:  
  https://projectreactor.io/ ([https](https://projectreactor.io/) result 200).
* http://repo.spring.io/libs-staging-local/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-staging-local/ ([https](https://repo.spring.io/libs-staging-local/) result 200).
* http://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java ([https](https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java) result 200).
* http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* http://www.ietf.org/rfc/rfc2396.txt with 2 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2396.txt ([https](https://www.ietf.org/rfc/rfc2396.txt) result 200).
* http://www.ietf.org/rfc/rfc2732.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2732.txt ([https](https://www.ietf.org/rfc/rfc2732.txt) result 200).
* http://repo.spring.io with 1 occurrences migrated to:  
  https://repo.spring.io ([https](https://repo.spring.io) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:15672/api/ with 4 occurrences
* http://localhost:15672/api/ with 7 occurrences