### PR TITLE
Federation upstream and upstream-set support

### DIFF
--- a/bin/before_build.sh
+++ b/bin/before_build.sh
@@ -27,5 +27,7 @@ $CTL eval 'supervisor2:terminate_child(rabbit_mgmt_agent_sup_sup, rabbit_mgmt_ag
 # Enable shovel plugin
 $PLUGINS enable rabbitmq_shovel
 $PLUGINS enable rabbitmq_shovel_management
+$PLUGINS enable rabbitmq_federation
+$PLUGINS enable rabbitmq_federation_management
 
 true

--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -29,10 +29,11 @@ import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 
-import com.rabbitmq.http.client.domain.ParameterWrapper;
 import com.rabbitmq.http.client.domain.TopicPermissions;
 import com.rabbitmq.http.client.domain.UpstreamDetails;
+import com.rabbitmq.http.client.domain.UpstreamInfo;
 import com.rabbitmq.http.client.domain.UpstreamSetDetails;
+import com.rabbitmq.http.client.domain.UpstreamSetInfo;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -887,11 +888,12 @@ public class Client {
     }
     final URI uri = uriWithPath("./parameters/federation-upstream/"
             + encodePathSegment(vhost) + "/" + encodePathSegment(name));
-    this.rt.put(uri, new ParameterWrapper<UpstreamDetails>()
-            .setComponent("federation-upstream")
-            .setVhost(vhost)
-            .setName(name)
-            .setValue(details));
+    UpstreamInfo body = new UpstreamInfo();
+    body.setComponent("federation-upstream");
+    body.setVhost(vhost);
+    body.setName(name);
+    body.setValue(details);
+    this.rt.put(uri, body);
   }
 
   /**
@@ -907,7 +909,7 @@ public class Client {
   /**
    * Returns a list of upstreams for "/" virtual host
    */
-  public List<ParameterWrapper<UpstreamDetails>> getUpstreams() {
+  public List<UpstreamInfo> getUpstreams() {
     return getParameters("federation-upstream");
   }
 
@@ -915,7 +917,7 @@ public class Client {
    * Returns a list of upstreams
    * @param vhost virtual host the upstreams are in.
    */
-  public List<ParameterWrapper<UpstreamDetails>> getUpstreams(String vhost) {
+  public List<UpstreamInfo> getUpstreams(String vhost) {
     return getParameters(vhost, "federation-upstream");
 
   }
@@ -935,11 +937,12 @@ public class Client {
     }
     final URI uri = uriWithPath("./parameters/federation-upstream-set/"
             + encodePathSegment(vhost) + "/" + encodePathSegment(name));
-    this.rt.put(uri, new ParameterWrapper<List<UpstreamSetDetails>>()
-            .setComponent("federation-upstream-set")
-            .setVhost(vhost)
-            .setName(name)
-            .setValue(details));
+    UpstreamSetInfo body = new UpstreamSetInfo();
+    body.setComponent("federation-upstream-set");
+    body.setVhost(vhost);
+    body.setName(name);
+    body.setValue(details);
+    this.rt.put(uri, body);
   }
 
   /**
@@ -955,7 +958,7 @@ public class Client {
   /**
    * Returns a list of upstream sets for "/" virtual host
    */
-  public List<ParameterWrapper<List<UpstreamSetDetails>>> getUpstreamSets() {
+  public List<UpstreamSetInfo> getUpstreamSets() {
     return getParameters("federation-upstream-set");
   }
 
@@ -963,21 +966,18 @@ public class Client {
    * Returns a ist of upstream sets
    * @param vhost Virtual host from where to get upstreams.
    */
-  public List<ParameterWrapper<List<UpstreamSetDetails>>> getUpstreamSets(String vhost) {
+  public List<UpstreamSetInfo> getUpstreamSets(String vhost) {
     return getParameters(vhost, "federation-upstream-set");
   }
 
-  private <T> List<ParameterWrapper<T>> getParameters(String component) {
+  private <T> List<T> getParameters(String component) {
     final URI uri = uriWithPath("./parameters/" + component + "/");
-    return rt.exchange(uri, HttpMethod.GET, null,
-            new ParameterizedTypeReference<List<ParameterWrapper<T>>>(){})
-            .getBody();
+    return rt.exchange(uri, HttpMethod.GET, null, new ParameterizedTypeReference<List<T>>(){}).getBody();
   }
 
-  private <T> List<ParameterWrapper<T>> getParameters(String vhost, String component) {
+  private <T> List<T> getParameters(String vhost, String component) {
     final URI uri = uriWithPath("./parameters/" + component + "/" + encodePathSegment(vhost));
-    return getForObjectReturningNullOn404(uri,
-            new ParameterizedTypeReference<List<ParameterWrapper<T>>>(){});
+    return getForObjectReturningNullOn404(uri, new ParameterizedTypeReference<List<T>>(){});
   }
 
   //

--- a/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
+++ b/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
@@ -30,7 +30,6 @@ import com.rabbitmq.http.client.domain.Definitions;
 import com.rabbitmq.http.client.domain.ExchangeInfo;
 import com.rabbitmq.http.client.domain.NodeInfo;
 import com.rabbitmq.http.client.domain.OverviewResponse;
-import com.rabbitmq.http.client.domain.ParameterWrapper;
 import com.rabbitmq.http.client.domain.PolicyInfo;
 import com.rabbitmq.http.client.domain.QueueInfo;
 import com.rabbitmq.http.client.domain.ShovelInfo;
@@ -544,6 +543,7 @@ public class ReactorNettyClient {
     //
     // Federation support
     //
+
     /**
      * Declares an upstream
      * @param vhost virtual host for which to declare the upstream
@@ -554,11 +554,11 @@ public class ReactorNettyClient {
         if (StringUtils.isEmpty(details.getUri())) {
             throw new IllegalArgumentException("Upstream uri must not be null or empty");
         }
-        ParameterWrapper<UpstreamDetails> body = new ParameterWrapper<UpstreamDetails>()
-                .setComponent("federation-upstream")
-                .setVhost(vhost)
-                .setName(name)
-                .setValue(details);
+        UpstreamInfo body = new UpstreamInfo();
+        body.setComponent("federation-upstream");
+        body.setVhost(vhost);
+        body.setName(name);
+        body.setValue(details);
         return doPut(body, "parameters", "federation-upstream", enc(vhost), enc(name));
     }
 
@@ -600,11 +600,11 @@ public class ReactorNettyClient {
                         "empty upstream name");
             }
         }
-        ParameterWrapper<List<UpstreamSetDetails>> body = new ParameterWrapper<List<UpstreamSetDetails>>()
-                .setComponent("federation-upstream-set")
-                .setVhost(vhost)
-                .setName(name)
-                .setValue(details);
+        UpstreamSetInfo body = new UpstreamSetInfo();
+        body.setComponent("federation-upstream-set");
+        body.setVhost(vhost);
+        body.setName(name);
+        body.setValue(details);
         return doPut(body, "parameters", "federation-upstream-set", enc(vhost), enc(name));
     }
 

--- a/src/main/java/com/rabbitmq/http/client/domain/AckMode.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/AckMode.java
@@ -1,0 +1,36 @@
+package com.rabbitmq.http.client.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AckMode {
+    /**
+     * Messages are acknowledged to the upstream broker after they have been confirmed downstream. This handles network
+     * errors and broker failures without losing messages, and is the slowest option.
+     */
+    ON_CONFIRM("on-confirm"),
+
+    /**
+     * Messages are acknowledged to the upstream broker after they have been published downstream. This handles network
+     * errors without losing messages, but may lose messages in the event of broker failures.
+     */
+    ON_PUBLISH("on-publish"),
+
+    /**
+     * Message acknowledgements are not used. This is the fastest option, but may lose messages in the event of network
+     * or broker failures.
+     */
+    NO_ACK("no-ack");
+
+    @JsonCreator
+    AckMode(String value) {
+        this.value = value;
+    }
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/ParameterWrapper.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ParameterWrapper.java
@@ -1,0 +1,57 @@
+package com.rabbitmq.http.client.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ParameterWrapper<T> {
+    private String name;
+    private String vhost;
+    private String component;
+    private T value;
+
+    public String getName() {
+        return name;
+    }
+
+    public ParameterWrapper<T> setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getVhost() {
+        return vhost;
+    }
+
+    public ParameterWrapper<T> setVhost(String vhost) {
+        this.vhost = vhost;
+        return this;
+    }
+
+    public String getComponent() {
+        return component;
+    }
+
+    public ParameterWrapper<T> setComponent(String component) {
+        this.component = component;
+        return this;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public ParameterWrapper<T> setValue(T value) {
+        this.value = value;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "ParameterWrapper{" +
+                "name='" + name + '\'' +
+                ", vhost='" + vhost + '\'' +
+                ", component='" + component + '\'' +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/RuntimeParameter.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/RuntimeParameter.java
@@ -3,7 +3,7 @@ package com.rabbitmq.http.client.domain;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ParameterWrapper<T> {
+public class RuntimeParameter<T> {
     private String name;
     private String vhost;
     private String component;
@@ -13,41 +13,37 @@ public class ParameterWrapper<T> {
         return name;
     }
 
-    public ParameterWrapper<T> setName(String name) {
+    public void setName(String name) {
         this.name = name;
-        return this;
     }
 
     public String getVhost() {
         return vhost;
     }
 
-    public ParameterWrapper<T> setVhost(String vhost) {
+    public void setVhost(String vhost) {
         this.vhost = vhost;
-        return this;
     }
 
     public String getComponent() {
         return component;
     }
 
-    public ParameterWrapper<T> setComponent(String component) {
+    public void setComponent(String component) {
         this.component = component;
-        return this;
     }
 
     public T getValue() {
         return value;
     }
 
-    public ParameterWrapper<T> setValue(T value) {
+    public void setValue(T value) {
         this.value = value;
-        return this;
     }
 
     @Override
     public String toString() {
-        return "ParameterWrapper{" +
+        return "RuntimeParameter{" +
                 "name='" + name + '\'' +
                 ", vhost='" + vhost + '\'' +
                 ", component='" + component + '\'' +

--- a/src/main/java/com/rabbitmq/http/client/domain/UpstreamDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/UpstreamDetails.java
@@ -1,0 +1,202 @@
+package com.rabbitmq.http.client.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class UpstreamDetails {
+
+    /**
+     * The AMQP URI for the upstream. Mandatory.<br/>
+     * E.g. amqp://guest:guest@localhost:5672/vhost<br/>
+     * E.g. amqp://guest:guest@localhost:5672 (nb! no slash at the end at in case of "/" virtual host)<br/>
+     * E.g. amqp://guest:guest@localhost:5671?cacertfile=/certs/cacert.pem
+     * (<a href="https://www.rabbitmq.com/uri-query-parameters.html">query-parameter reference</a>)<br/>
+     * Applying to federated exchanges and federated queues
+     */
+    private String uri;
+
+    /**
+     * The maximum number of unacknowledged messages copied over a link at any one time. Default is 1000.<br/>
+     * Applying to federated exchanges and federated queues
+     */
+    @JsonProperty("prefetch-count")
+    private Integer prefetchCount;
+
+    /**
+     * The duration (in seconds) to wait before reconnecting to the broker after being disconnected. Default is 1.<br/>
+     * Applying to federated exchanges and federated queues
+     */
+    @JsonProperty("reconnect-delay")
+    private Integer reconnectDelay;
+
+    /**
+     * <p>Determines how the link should acknowledge messages. If set to <b>on-confirm</b> (the default), messages are
+     * acknowledged to the upstream broker after they have been confirmed downstream. This handles network errors and
+     * broker failures without losing messages, and is the slowest option.</p>
+     * <p>If set to <b>on-publish</b>, messages are acknowledged to the upstream broker after they have been published
+     * downstream. This handles network errors without losing messages, but may lose messages in the event of broker
+     * failures.</p>
+     * <p>If set to <b>no-ack</b>, message acknowledgements are not used. This is the fastest option, but may lose
+     * messages in the event of network or broker failures.</p>
+     * Applying to federated exchanges and federated queues
+     */
+    private AckMode ackMode;
+
+    /**
+     * Determines how federation should interact with the <a href="https://www.rabbitmq.com/validated-user-id.html">
+     * validated user-id</a> feature. If set to true, federation will pass through any validated user-id from the
+     * upstream, even though it cannot validate it itself. If set to false or not set, it will clear any validated
+     * user-id it encounters. You should only set this to true if you trust the upstream server (and by extension, all
+     * its upstreams) not to forge user-ids.<br/>
+     * Applying to federated exchanges and federated queues
+     * @see <a href="https://www.rabbitmq.com/validated-user-id.html">validated user-id reference</a>
+     */
+    @JsonProperty("trust-user-id")
+    private Boolean trustUserId;
+
+    /**
+     * The name of the upstream exchange. Default is to use the same name as the federated exchange.
+     */
+    private String exchange;
+
+    /**
+     * The maximum number of federation links that a message published to a federated exchange can traverse before it is
+     * discarded. Default is 1. Note that even if max-hops is set to a value greater than 1, messages will never visit
+     * the same node twice due to travelling in a loop. However, messages may still be duplicated if it is possible for
+     * them to travel from the source to the destination via multiple routes.
+     * Applying to federated exchanges only
+     */
+    @JsonProperty("max-hops")
+    private Integer maxHops;
+
+    /**
+     * <p>The expiry time (in milliseconds) after which an upstream queue for a federated exchange may be deleted, if a
+     * connection to the upstream broker is lost. The default is 'none', meaning the queue should never expire.</p>
+     * <p>This setting controls how long the upstream queue will last before it is eligible for deletion if the
+     * connection is lost.</p>
+     * <p>This value is used to set the <b>"x-expires"</b> argument for the upstream queue.</p>
+     * Applying to federated exchanges only
+     */
+    @JsonProperty("expires")
+    private Long expiresMillis;
+
+    /**
+     * <p>The expiry time for messages in the upstream queue for a federated exchange (see {@link
+     * UpstreamDetails#expiresMillis}), in milliseconds. Default is 'none', meaning messages should never expire.</p>
+     * <p>This value is used to set the <b>"x-message-ttl"</b> argument for the upstream queue.</p>
+     * Applying to federated exchanges only
+     */
+    @JsonProperty("message-ttl")
+    private Long messageTtl;
+
+    /**
+     * The name of the upstream queue. Default is to use the same name as the federated queue.<br/>
+     * Applying to federated queues only
+     */
+    private String queue;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public UpstreamDetails setUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Integer getPrefetchCount() {
+        return prefetchCount;
+    }
+
+    public UpstreamDetails setPrefetchCount(Integer prefetchCount) {
+        this.prefetchCount = prefetchCount;
+        return this;
+    }
+
+    public Integer getReconnectDelay() {
+        return reconnectDelay;
+    }
+
+    public UpstreamDetails setReconnectDelay(Integer reconnectDelay) {
+        this.reconnectDelay = reconnectDelay;
+        return this;
+    }
+
+    public AckMode getAckMode() {
+        return ackMode;
+    }
+
+    public UpstreamDetails setAckMode(AckMode ackMode) {
+        this.ackMode = ackMode;
+        return this;
+    }
+
+    public Boolean getTrustUserId() {
+        return trustUserId;
+    }
+
+    public UpstreamDetails setTrustUserId(Boolean trustUserId) {
+        this.trustUserId = trustUserId;
+        return this;
+    }
+
+    public String getExchange() {
+        return exchange;
+    }
+
+    public UpstreamDetails setExchange(String exchange) {
+        this.exchange = exchange;
+        return this;
+    }
+
+    public Integer getMaxHops() {
+        return maxHops;
+    }
+
+    public UpstreamDetails setMaxHops(Integer maxHops) {
+        this.maxHops = maxHops;
+        return this;
+    }
+
+    public Long getExpiresMillis() {
+        return expiresMillis;
+    }
+
+    public UpstreamDetails setExpiresMillis(Long expiresMillis) {
+        this.expiresMillis = expiresMillis;
+        return this;
+    }
+
+    public Long getMessageTtl() {
+        return messageTtl;
+    }
+
+    public UpstreamDetails setMessageTtl(Long messageTtl) {
+        this.messageTtl = messageTtl;
+        return this;
+    }
+
+    public String getQueue() {
+        return queue;
+    }
+
+    public UpstreamDetails setQueue(String queue) {
+        this.queue = queue;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "UpstreamDetails{" +
+                "uri='" + uri + '\'' +
+                ", prefetchCount=" + prefetchCount +
+                ", reconnectDelay=" + reconnectDelay +
+                ", ackMode=" + ackMode +
+                ", trustUserId=" + trustUserId +
+                ", exchange='" + exchange + '\'' +
+                ", maxHops=" + maxHops +
+                ", expiresMillis=" + expiresMillis +
+                ", messageTtl=" + messageTtl +
+                ", queue='" + queue + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/UpstreamInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/UpstreamInfo.java
@@ -1,4 +1,4 @@
 package com.rabbitmq.http.client.domain;
 
-public class UpstreamInfo extends ParameterWrapper<UpstreamDetails> {
+public class UpstreamInfo extends RuntimeParameter<UpstreamDetails> {
 }

--- a/src/main/java/com/rabbitmq/http/client/domain/UpstreamInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/UpstreamInfo.java
@@ -1,0 +1,4 @@
+package com.rabbitmq.http.client.domain;
+
+public class UpstreamInfo extends ParameterWrapper<UpstreamDetails> {
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/UpstreamSetDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/UpstreamSetDetails.java
@@ -1,0 +1,27 @@
+package com.rabbitmq.http.client.domain;
+
+/**
+ * Any of the properties from an upstream can be overridden in an upstream set.
+ */
+public class UpstreamSetDetails extends UpstreamDetails {
+    /**
+     * The name of an upstream. Mandatory.
+     */
+    private String upstream;
+
+    public String getUpstream() {
+        return upstream;
+    }
+
+    public UpstreamSetDetails setUpstream(String upstream) {
+        this.upstream = upstream;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "UpstreamSetDetails{" +
+                "upstream='" + upstream + '\'' +
+                "} " + super.toString();
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/UpstreamSetInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/UpstreamSetInfo.java
@@ -1,0 +1,6 @@
+package com.rabbitmq.http.client.domain;
+
+import java.util.List;
+
+public class UpstreamSetInfo extends ParameterWrapper<List<UpstreamSetDetails>> {
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/UpstreamSetInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/UpstreamSetInfo.java
@@ -2,5 +2,5 @@ package com.rabbitmq.http.client.domain;
 
 import java.util.List;
 
-public class UpstreamSetInfo extends ParameterWrapper<List<UpstreamSetDetails>> {
+public class UpstreamSetInfo extends RuntimeParameter<List<UpstreamSetDetails>> {
 }

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -1709,6 +1709,130 @@ class ClientSpec extends Specification {
     client.deleteShovel("/", shovelName)
   }
 
+  def "GET /api/parameters/federation-upstream declare and get at root vhost"() {
+    given: "an upstream"
+    final vhost = "/"
+    final upstreamName = "upstream1"
+    declareUpstream(client, vhost, upstreamName)
+
+    when: "client requests the upstreams"
+    final upstreams = awaitEventPropagation { client.getUpstreams() }
+
+    then: "list of upstreams that contains the new upstream is returned"
+    verifyUpstreamDefinitions(vhost, upstreams, upstreamName)
+
+    cleanup:
+    client.deleteUpstream(vhost, upstreamName)
+  }
+
+  def "GET /api/parameters/federation-upstream declare and get at non-root vhost"() {
+    given: "an upstream"
+    final vhost = "foo"
+    final upstreamName = "upstream2"
+    client.createVhost(vhost)
+    declareUpstream(client, vhost, upstreamName)
+
+    when: "client requests the upstreams"
+    final upstreams = awaitEventPropagation { client.getUpstreams(vhost) }
+
+    then: "list of upstreams that contains the new upstream is returned"
+    verifyUpstreamDefinitions(vhost, upstreams, upstreamName)
+
+    cleanup:
+    client.deleteUpstream(vhost,upstreamName)
+    client.deleteVhost(vhost)
+  }
+
+  def "PUT /api/parameters/federation-upstream with null upstream uri"() {
+    given: "an Upstream without upstream uri"
+    UpstreamDetails upstreamDetails = new UpstreamDetails()
+
+    when: "client tries to declare an Upstream"
+    client.declareUpstream("/", "upstream3", upstreamDetails)
+
+    then: "an illegal argument exception is thrown"
+    thrown(IllegalArgumentException)
+  }
+
+  def "DELETE /api/parameters/federation-upstream/{vhost}/{name}"() {
+    given: "upstream upstream4 in vhost /"
+    final vhost = "/"
+    final upstreamName = "upstream4"
+    declareUpstream(client, vhost, upstreamName)
+
+    List<ParameterWrapper<UpstreamDetails>> upstreams = awaitEventPropagation { client.getUpstreams() }
+    verifyUpstreamDefinitions(vhost, upstreams, upstreamName)
+
+    when: "client deletes upstream upstream4 in vhost /"
+    client.deleteUpstream(vhost, upstreamName)
+
+    and: "upstream list in / is reloaded"
+    upstreams = client.getUpstreams()
+
+    then: "upstream4 no longer exists"
+    upstreams.find { it.name.equals(upstreamName) } == null
+  }
+
+  def "GET /api/parameters/federation-upstream-set declare and get"() {
+    given: "an upstream set with two upstreams"
+    final vhost = "/"
+    final upstreamSetName = "upstream-set-1"
+    final upstreamA = "A"
+    final upstreamB = "B"
+    declareUpstream(client, vhost, upstreamA);
+    declareUpstream(client, vhost, upstreamB);
+    final d1 = new UpstreamSetDetails()
+    d1.setUpstream(upstreamA)
+    d1.setExchange("exchangeA")
+    final d2 = new UpstreamSetDetails()
+    d2.setUpstream(upstreamB)
+    d2.setExchange("exchangeB")
+    final detailsSet = new ArrayList()
+    detailsSet.add(d1)
+    detailsSet.add(d2)
+    client.declareUpstreamSet(vhost, upstreamSetName, detailsSet)
+
+    when: "client requests the upstream set list"
+    final upstreamSets = awaitEventPropagation { client.getUpstreamSets() }
+
+    then: "upstream set with two upstreams is returned"
+    assert !upstreamSets.isEmpty()
+    ParameterWrapper<UpstreamSetDetails> upstreamSet = upstreamSets.find { it.name.equals(upstreamSetName) }
+    assert upstreamSet != null
+    assert upstreamSet.name.equals(upstreamSetName)
+    assert upstreamSet.vhost.equals(vhost)
+    assert upstreamSet.component.equals("federation-upstream-set")
+    List<UpstreamSetDetails> upstreams = upstreamSet.value
+    assert upstreams != null
+    assert upstreams.size() == 2
+    UpstreamSetDetails responseUpstreamA = upstreams.find { it.upstream.equals(upstreamA) }
+    assert responseUpstreamA != null
+    assert responseUpstreamA.upstream.equals(upstreamA)
+    assert responseUpstreamA.exchange.equals("exchangeA")
+    UpstreamSetDetails responseUpstreamB = upstreams.find { it.upstream.equals(upstreamB) }
+    assert responseUpstreamB != null
+    assert responseUpstreamB.upstream.equals(upstreamB)
+    assert responseUpstreamB.exchange.equals("exchangeB")
+
+    cleanup:
+    client.deleteUpstreamSet(vhost,upstreamSetName)
+    client.deleteUpstream(vhost,upstreamA)
+    client.deleteUpstream(vhost,upstreamB)
+  }
+
+  def "PUT /api/parameters/federation-upstream-set without upstreams"() {
+    given: "an Upstream without upstream uri"
+    final upstreamSetDetails = new UpstreamSetDetails()
+    final detailsSet = new ArrayList()
+    detailsSet.add(upstreamSetDetails)
+
+    when: "client tries to declare an Upstream"
+    client.declareUpstreamSet("/", "upstrea-set-2", detailsSet);
+
+    then: "an illegal argument exception is thrown"
+    thrown(IllegalArgumentException)
+  }
+
   protected static boolean awaitOn(CountDownLatch latch) {
     latch.await(10, TimeUnit.SECONDS)
   }
@@ -1857,6 +1981,22 @@ class ClientSpec extends Specification {
         result = client.getConnections()
       }
       result
+  }
+
+  protected static void declareUpstream(client, vhost, upstreamName) {
+    UpstreamDetails upstreamDetails = new UpstreamDetails()
+    upstreamDetails.setUri("amqp://localhost:5672")
+    client.declareUpstream(vhost, upstreamName, upstreamDetails)
+  }
+
+  protected static void verifyUpstreamDefinitions(vhost, upstreams, upstreamName) {
+    assert !upstreams.isEmpty()
+    ParameterWrapper<UpstreamDetails> upstream = upstreams.find { it.name.equals(upstreamName) }
+    assert upstream != null
+    assert upstream.name.equals(upstreamName)
+    assert upstream.vhost.equals(vhost)
+    assert upstream.component.equals("federation-upstream")
+    assert upstream.value.uri.equals("amqp://localhost:5672")
   }
 
   static class MockRestTemplate extends RestTemplate {

--- a/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
@@ -1828,7 +1828,7 @@ class ReactorNettyClientSpec extends Specification {
         final upstreamSetName = "upstream-set-1"
         final upstreamA = "A"
         final upstreamB = "B"
-        final policyName = "ppp"
+        final policyName = "federation-policy"
         declareUpstream(client, vhost, upstreamA);
         declareUpstream(client, vhost, upstreamB);
         final d1 = new UpstreamSetDetails()
@@ -1852,23 +1852,23 @@ class ReactorNettyClientSpec extends Specification {
         Flux<UpstreamSetInfo> upstreamSets = awaitEventPropagation { client.getUpstreamSets() }
 
         then: "upstream set with two upstreams is returned"
-        assert upstreamSets.hasElements().block()
+        upstreamSets.hasElements().block()
         UpstreamSetInfo upstreamSet = upstreamSets.filter { it.name.equals(upstreamSetName) }.blockFirst()
-        assert upstreamSet != null
-        assert upstreamSet.name.equals(upstreamSetName)
-        assert upstreamSet.vhost.equals(vhost)
-        assert upstreamSet.component.equals("federation-upstream-set")
+        upstreamSet != null
+        upstreamSet.name.equals(upstreamSetName)
+        upstreamSet.vhost.equals(vhost)
+        upstreamSet.component.equals("federation-upstream-set")
         List<UpstreamSetDetails> upstreams = upstreamSet.value
-        assert upstreams != null
-        assert upstreams.size() == 2
+        upstreams != null
+        upstreams.size() == 2
         UpstreamSetDetails responseUpstreamA = upstreams.find { it.upstream.equals(upstreamA) }
-        assert responseUpstreamA != null
-        assert responseUpstreamA.upstream.equals(upstreamA)
-        assert responseUpstreamA.exchange.equals("amq.direct")
+        responseUpstreamA != null
+        responseUpstreamA.upstream.equals(upstreamA)
+        responseUpstreamA.exchange.equals("amq.direct")
         UpstreamSetDetails responseUpstreamB = upstreams.find { it.upstream.equals(upstreamB) }
-        assert responseUpstreamB != null
-        assert responseUpstreamB.upstream.equals(upstreamB)
-        assert responseUpstreamB.exchange.equals("amq.fanout")
+        responseUpstreamB != null
+        responseUpstreamB.upstream.equals(upstreamB)
+        responseUpstreamB.exchange.equals("amq.fanout")
 
         cleanup:
         client.deletePolicy(vhost, policyName)


### PR DESCRIPTION
Added methods to declare, delete and get the list of upstreams and upstream sets. Along with the ability to manage policies that should allow managing RabbitMQ federations.
