### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you want to use the **reactive, non-blocking IO client**, add the following d
   <version>3.3.0.RELEASE</version>
 </dependency>
 <dependency>
-  <groupId>io.projectreactor.ipc</groupId>
+  <groupId>io.projectreactor.netty</groupId>
   <artifactId>reactor-netty</artifactId>
   <version>0.8.9.RELEASE</version>
 </dependency>
@@ -96,7 +96,7 @@ If you want to use the **reactive, non-blocking IO client**, add the following d
 
 ```groovy
 compile "com.rabbitmq:http-client:3.3.0.RELEASE"
-compile "io.projectreactor.ipc:reactor-netty:0.8.9.RELEASE"
+compile "io.projectreactor.netty:reactor-netty:0.8.9.RELEASE"
 compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.3"
 ```
 


### PR DESCRIPTION
fix reactor-netty version

there is no "io.projectreactor.ipc:reactor-netty:0.8.9.RELEASE". you can see [io.projectreactor.ipc:reactor-netty index](https://repo1.maven.org/maven2/io/projectreactor/ipc/reactor-netty/)

but "io.projectreactor.netty:reactor-netty:0.8.9.RELEASE", [io.projectreactor.netty:reactor-netty index](https://repo1.maven.org/maven2/io/projectreactor/netty/reactor-netty/)