### PR TITLE
Expose consumer_details in QueueInfo

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/domain/ConsumerDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ConsumerDetails.java
@@ -35,6 +35,8 @@ public class ConsumerDetails {
   private Map<String, Object> arguments;
   @JsonProperty("queue")
   private QueueDetails queueDetails;
+  @JsonProperty("active")
+  private boolean active = true;
 
   public String getConsumerTag() {
     return consumerTag;
@@ -84,6 +86,14 @@ public class ConsumerDetails {
     this.queueDetails = queueDetails;
   }
 
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
   @Override
   public String toString() {
     return "ConsumerDetails{" +
@@ -93,6 +103,7 @@ public class ConsumerDetails {
         ", exclusive=" + exclusive +
         ", arguments=" + arguments +
         ", queueDetails=" + queueDetails +
+        ", active='" + active +
         '}';
   }
 }

--- a/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 //{
@@ -149,6 +150,10 @@ public class QueueInfo {
   // TODO: should we expose backing_queue_status,
   //       which is an implementation detail?
 
+  @JsonProperty("consumer_details")
+  private List<ConsumerDetails> consumerDetails;
+  @JsonProperty("single_active_consumer_tag")
+  private String singleActiveConsumerTag;
 
   public QueueInfo() {
   }
@@ -402,6 +407,22 @@ public class QueueInfo {
     this.ownerPidDetails = ownerPidDetails;
   }
 
+  public List<ConsumerDetails> getConsumerDetails() {
+    return consumerDetails;
+  }
+
+  public void setConsumerDetails(List<ConsumerDetails> consumerDetails) {
+    this.consumerDetails = consumerDetails;
+  }
+
+  public String getSingleActiveConsumerTag() {
+    return singleActiveConsumerTag;
+  }
+
+  public void setSingleActiveConsumerTag(String singleActiveConsumerTag) {
+    this.singleActiveConsumerTag = singleActiveConsumerTag;
+  }
+
   @Override
   public String toString() {
     return "QueueInfo{" +
@@ -433,6 +454,7 @@ public class QueueInfo {
         ", messagesUnacknowledged=" + messagesUnacknowledged +
         ", messagesUnacknowledgedDetails=" + messagesUnacknowledgedDetails +
         ", consumerCount=" + consumerCount +
+        ", singleActiveConsumerTag=" + singleActiveConsumerTag +
         '}';
   }
 }


### PR DESCRIPTION
This information (`consumer_details`) is already downloaded when
we retrieve the queue information. However, we were not exposing it.

Note: This is meant for +3.8.x RabbitMQ brokers and leverages Single-Active-Consumer feature