### PR TITLE
Use -1 for longs in QueueInfo

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -18,6 +18,7 @@ package com.rabbitmq.http.client;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.http.client.domain.*;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -1296,13 +1297,17 @@ public class Client {
 
   private List<HttpMessageConverter<?>> getMessageConverters() {
     List<HttpMessageConverter<?>> xs = new ArrayList<HttpMessageConverter<?>>();
-    final Jackson2ObjectMapperBuilder bldr = Jackson2ObjectMapperBuilder
+    xs.add(new MappingJackson2HttpMessageConverter(createDefaultObjectMapper()));
+    return xs;
+  }
+
+  static ObjectMapper createDefaultObjectMapper() {
+    return Jackson2ObjectMapperBuilder
         .json()
         .serializationInclusion(JsonInclude.Include.NON_NULL)
         .featuresToEnable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
-        .deserializerByType(VhostLimits.class, Utils.VHOST_LIMITS_JSON_DESERIALIZER);
-    xs.add(new MappingJackson2HttpMessageConverter(bldr.build()));
-    return xs;
+        .deserializerByType(VhostLimits.class, Utils.VHOST_LIMITS_JSON_DESERIALIZER)
+        .build();
   }
 
   private <T> T getForObjectReturningNullOn404(final URI uri, final Class<T> klass) {

--- a/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
@@ -104,35 +104,35 @@ public class QueueInfo {
   private String idleSince;
 
   @JsonProperty("disk_reads")
-  private long diskReads;
+  private long diskReads = -1;
   @JsonProperty("disk_writes")
-  private long diskWrites;
+  private long diskWrites = -1;
   @JsonProperty("memory")
-  private long memoryUsed;
+  private long memoryUsed = -1;
   @JsonProperty("message_bytes")
-  private long messageBytes;
+  private long messageBytes = -1;
   @JsonProperty("message_bytes_persistent")
-  private long messageBytesPersistent;
+  private long messageBytesPersistent = -1;
   @JsonProperty("message_bytes_ram")
-  private long messageBytesRAM;
+  private long messageBytesRAM = -1;
   @JsonProperty("message_bytes_ready")
-  private long messageBytesReady;
+  private long messageBytesReady = -1;
   @JsonProperty("message_bytes_unacknowledged")
-  private long messageBytesUnacknowledged;
+  private long messageBytesUnacknowledged = -1;
   @JsonProperty("messages")
-  private long totalMessages;
+  private long totalMessages = -1;
   @JsonProperty("message_stats")
   private MessageStats messageStats;
   @JsonProperty("messages_persistent")
-  private long totalPersistentMessages;
+  private long totalPersistentMessages = -1;
   @JsonProperty("messages_ram")
-  private long totalTransientMessages;
+  private long totalTransientMessages = -1;
   @JsonProperty("messages_ready")
-  private long messagesReady;
+  private long messagesReady = -1;
   @JsonProperty("messages_ready_details")
   private RateDetails messagesReadyDetails;
   @JsonProperty("messages_unacknowledged")
-  private long messagesUnacknowledged;
+  private long messagesUnacknowledged = -1;
   @JsonProperty("messages_unacknowledged_details")
   private RateDetails messagesUnacknowledgedDetails;
   @JsonProperty("owner_pid_details")

--- a/src/test/groovy/com/rabbitmq/http/client/JsonMappingSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/JsonMappingSpec.groovy
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rabbitmq.http.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.rabbitmq.http.client.domain.QueueInfo
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class JsonMappingSpec extends Specification {
+
+  static ObjectMapper[] mappers() {
+    [Client.createDefaultObjectMapper(), ReactorNettyClient.createDefaultObjectMapper()]
+  }
+
+  @Unroll
+  def "JSON document for queue with NaN message count should return -1 for message count"() {
+    when: "JSON document for queue has no ready messages count field"
+    def q = mapper.readValue(JSON_QUEUE_NO_READY_MESSAGES, QueueInfo.class)
+
+    then: "the field value should be -1 in the Java object"
+    q.messagesReady == -1
+
+    where:
+    mapper << mappers()
+  }
+
+  @Unroll
+  def "JSON document for queue with defined message count should return appropriate value for message count"() {
+    when: "JSON document for queue has a ready messages count field with a value"
+    def q = Client.createDefaultObjectMapper().readValue(JSON_QUEUE_SOME_READY_MESSAGES, QueueInfo.class)
+
+    then: "the field value of the Java object should be the same as in the JSON document"
+    q.messagesReady == 1000
+
+    where:
+    mapper << mappers()
+  }
+
+  static final String JSON_QUEUE_NO_READY_MESSAGES =
+          "   {\n" +
+          "      \"arguments\":{\n" +
+          "         \n" +
+          "      },\n" +
+          "      \"auto_delete\":false,\n" +
+          "      \"backing_queue_status\":{\n" +
+          "         \"avg_ack_egress_rate\":0.0,\n" +
+          "         \"avg_ack_ingress_rate\":0.0,\n" +
+          "         \"avg_egress_rate\":0.0,\n" +
+          "         \"avg_ingress_rate\":0.0,\n" +
+          "         \"delta\":[\n" +
+          "            \"delta\",\n" +
+          "            \"undefined\",\n" +
+          "            0,\n" +
+          "            0,\n" +
+          "            \"undefined\"\n" +
+          "         ],\n" +
+          "         \"len\":0,\n" +
+          "         \"mode\":\"default\",\n" +
+          "         \"next_seq_id\":0,\n" +
+          "         \"q1\":0,\n" +
+          "         \"q2\":0,\n" +
+          "         \"q3\":0,\n" +
+          "         \"q4\":0,\n" +
+          "         \"target_ram_count\":\"infinity\"\n" +
+          "      },\n" +
+          "      \"consumer_utilisation\":null,\n" +
+          "      \"consumers\":0,\n" +
+          "      \"durable\":true,\n" +
+          "      \"effective_policy_definition\":{\n" +
+          "         \n" +
+          "      },\n" +
+          "      \"exclusive\":false,\n" +
+          "      \"exclusive_consumer_tag\":null,\n" +
+          "      \"garbage_collection\":{\n" +
+          "         \"fullsweep_after\":65535,\n" +
+          "         \"max_heap_size\":0,\n" +
+          "         \"min_bin_vheap_size\":46422,\n" +
+          "         \"min_heap_size\":233,\n" +
+          "         \"minor_gcs\":2\n" +
+          "      },\n" +
+          "      \"head_message_timestamp\":null,\n" +
+          "      \"idle_since\":\"2020-10-08 7:35:55\",\n" +
+          "      \"memory\":18260,\n" +
+          "      \"message_bytes\":0,\n" +
+          "      \"message_bytes_paged_out\":0,\n" +
+          "      \"message_bytes_persistent\":0,\n" +
+          "      \"message_bytes_ram\":0,\n" +
+          "      \"message_bytes_ready\":0,\n" +
+          "      \"message_bytes_unacknowledged\":0,\n" +
+          "      \"messages\":0,\n" +
+          "      \"messages_details\":{\n" +
+          "         \"rate\":0.0\n" +
+          "      },\n" +
+          "      \"messages_paged_out\":0,\n" +
+          "      \"messages_persistent\":0,\n" +
+          "      \"messages_ram\":0,\n" +
+          "      \"messages_ready_details\":{\n" +
+          "         \"rate\":0.0\n" +
+          "      },\n" +
+          "      \"messages_ready_ram\":0,\n" +
+          "      \"messages_unacknowledged\":0,\n" +
+          "      \"messages_unacknowledged_details\":{\n" +
+          "         \"rate\":0.0\n" +
+          "      },\n" +
+          "      \"messages_unacknowledged_ram\":0,\n" +
+          "      \"name\":\"queue1\",\n" +
+          "      \"operator_policy\":null,\n" +
+          "      \"policy\":null,\n" +
+          "      \"recoverable_slaves\":null,\n" +
+          "      \"reductions\":4474,\n" +
+          "      \"reductions_details\":{\n" +
+          "         \"rate\":0.0\n" +
+          "      },\n" +
+          "      \"single_active_consumer_tag\":null,\n" +
+          "      \"state\":\"running\",\n" +
+          "      \"type\":\"classic\",\n" +
+          "      \"vhost\":\"vh1\"\n" +
+          "   }\n"
+
+  static final String JSON_QUEUE_SOME_READY_MESSAGES =
+          "   {\n" +
+                  "      \"arguments\":{\n" +
+                  "         \n" +
+                  "      },\n" +
+                  "      \"auto_delete\":false,\n" +
+                  "      \"backing_queue_status\":{\n" +
+                  "         \"avg_ack_egress_rate\":0.0,\n" +
+                  "         \"avg_ack_ingress_rate\":0.0,\n" +
+                  "         \"avg_egress_rate\":0.0,\n" +
+                  "         \"avg_ingress_rate\":0.0,\n" +
+                  "         \"delta\":[\n" +
+                  "            \"delta\",\n" +
+                  "            \"undefined\",\n" +
+                  "            0,\n" +
+                  "            0,\n" +
+                  "            \"undefined\"\n" +
+                  "         ],\n" +
+                  "         \"len\":0,\n" +
+                  "         \"mode\":\"default\",\n" +
+                  "         \"next_seq_id\":0,\n" +
+                  "         \"q1\":0,\n" +
+                  "         \"q2\":0,\n" +
+                  "         \"q3\":0,\n" +
+                  "         \"q4\":0,\n" +
+                  "         \"target_ram_count\":\"infinity\"\n" +
+                  "      },\n" +
+                  "      \"consumer_utilisation\":null,\n" +
+                  "      \"consumers\":0,\n" +
+                  "      \"durable\":true,\n" +
+                  "      \"effective_policy_definition\":{\n" +
+                  "         \n" +
+                  "      },\n" +
+                  "      \"exclusive\":false,\n" +
+                  "      \"exclusive_consumer_tag\":null,\n" +
+                  "      \"garbage_collection\":{\n" +
+                  "         \"fullsweep_after\":65535,\n" +
+                  "         \"max_heap_size\":0,\n" +
+                  "         \"min_bin_vheap_size\":46422,\n" +
+                  "         \"min_heap_size\":233,\n" +
+                  "         \"minor_gcs\":2\n" +
+                  "      },\n" +
+                  "      \"head_message_timestamp\":null,\n" +
+                  "      \"idle_since\":\"2020-10-08 7:35:55\",\n" +
+                  "      \"memory\":18260,\n" +
+                  "      \"message_bytes\":0,\n" +
+                  "      \"message_bytes_paged_out\":0,\n" +
+                  "      \"message_bytes_persistent\":0,\n" +
+                  "      \"message_bytes_ram\":0,\n" +
+                  "      \"message_bytes_ready\":0,\n" +
+                  "      \"message_bytes_unacknowledged\":0,\n" +
+                  "      \"messages\":0,\n" +
+                  "      \"messages_details\":{\n" +
+                  "         \"rate\":0.0\n" +
+                  "      },\n" +
+                  "      \"messages_paged_out\":0,\n" +
+                  "      \"messages_persistent\":0,\n" +
+                  "      \"messages_ram\":0,\n" +
+                  "      \"messages_ready\":1000,\n" +
+                  "      \"messages_ready_details\":{\n" +
+                  "         \"rate\":0.0\n" +
+                  "      },\n" +
+                  "      \"messages_ready_ram\":0,\n" +
+                  "      \"messages_unacknowledged\":0,\n" +
+                  "      \"messages_unacknowledged_details\":{\n" +
+                  "         \"rate\":0.0\n" +
+                  "      },\n" +
+                  "      \"messages_unacknowledged_ram\":0,\n" +
+                  "      \"name\":\"queue1\",\n" +
+                  "      \"operator_policy\":null,\n" +
+                  "      \"policy\":null,\n" +
+                  "      \"recoverable_slaves\":null,\n" +
+                  "      \"reductions\":4474,\n" +
+                  "      \"reductions_details\":{\n" +
+                  "         \"rate\":0.0\n" +
+                  "      },\n" +
+                  "      \"single_active_consumer_tag\":null,\n" +
+                  "      \"state\":\"running\",\n" +
+                  "      \"type\":\"classic\",\n" +
+                  "      \"vhost\":\"vh1\"\n" +
+                  "   }\n"
+
+}


### PR DESCRIPTION
This commit sets -1 as the default for some long fields in QueueInfo.
This should help make the distinction between an empty queue (e.g. 0
message) and an unavailable queue (e.g. -1 message).

Right now, the value for those fields is 0 when the corresponding JSON
field is not present in the response, which can be confusing.

References #224

Fixes #229