### PR TITLE
Support query parameters to get queues, exchanges, connections and channels

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -318,6 +318,19 @@ public class Client {
   }
 
   /**
+   * Retrieves state and metrics information for all client connections across the cluster
+   * using query parameters
+   *
+   * @param queryParameters
+   * @return list of connections across the cluster
+   */
+  public ConnectionPagination getConnections(QueryParameters queryParameters) {
+    final URI uri = uriWithPath("./connections/", queryParameters);
+    return (queryParameters.pagination().hasAny()) ? this.rt.getForObject(uri, ConnectionPagination.class) :
+            new ConnectionPagination(this.rt.getForObject(uri, ConnectionInfo[].class));
+  }
+
+  /**
    * Retrieves state and metrics information for individual client connection.
    *
    * @param name connection name
@@ -363,6 +376,19 @@ public class Client {
   public List<ChannelInfo> getChannels() {
     final URI uri = uriWithPath("./channels/");
     return Arrays.asList(this.rt.getForObject(uri, ChannelInfo[].class));
+  }
+
+  /**
+   * Retrieves state and metrics information for all channels across the cluster.
+   * using query parameters
+   *
+   * @param queryParameters
+   * @return list of channels across the cluster
+   */
+  public ChannelPagination getChannels(QueryParameters queryParameters) {
+    final URI uri = uriWithPath("./channels/", queryParameters);
+    return (queryParameters.pagination().hasAny()) ? this.rt.getForObject(uri, ChannelPagination.class) :
+            new ChannelPagination(this.rt.getForObject(uri, ChannelInfo[].class));
   }
 
   /**
@@ -505,6 +531,12 @@ public class Client {
   public List<ExchangeInfo> getExchanges() {
     final URI uri = uriWithPath("./exchanges/");
     return Arrays.asList(this.rt.getForObject(uri, ExchangeInfo[].class));
+  }
+
+  public ExchangePagination getExchanges(QueryParameters queryParameters) {
+    final URI uri = uriWithPath("./exchange/", queryParameters);
+    return (queryParameters.pagination().hasAny()) ? this.rt.getForObject(uri, ExchangePagination.class) :
+            new ExchangePagination(this.rt.getForObject(uri, ExchangeInfo[].class));
   }
 
   public List<ExchangeInfo> getExchanges(String vhost) {

--- a/src/main/java/com/rabbitmq/http/client/domain/AbstractPagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/AbstractPagination.java
@@ -40,6 +40,7 @@ public abstract class AbstractPagination {
         itemCount = totalItems;
         totalCount = totalItems;
         pageCount = 1;
+        page = 1;
         pageSize = totalItems;
         filteredCount = totalItems;
     }

--- a/src/main/java/com/rabbitmq/http/client/domain/AbstractPagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/AbstractPagination.java
@@ -1,0 +1,95 @@
+package com.rabbitmq.http.client.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ *  {
+ *   "filtered_count": 3,
+ *   "item_count": 3,
+ *   "items": [
+ *      ...
+ *   ],
+ *   "page": 1,
+ *   "page_count": 1,
+ *   "page_size": 50,
+ *   "total_count": 3
+ *   }
+ */
+public abstract class AbstractPagination {
+    @JsonProperty("filtered_count")
+    private int filteredCount;
+    @JsonProperty("item_count")
+    private int itemCount;
+
+    private int page;
+    @JsonProperty("page_count")
+    private int pageCount;
+    @JsonProperty("page_size")
+    private int pageSize;
+    @JsonProperty("total_count")
+    private int totalCount;
+
+    public AbstractPagination() {
+    }
+
+    public AbstractPagination(int totalItems) {
+        itemCount = totalItems;
+        totalCount = totalItems;
+        pageCount = 1;
+        pageSize = totalItems;
+        filteredCount = totalItems;
+    }
+
+    public int getFilteredCount() {
+        return filteredCount;
+    }
+
+    public void setFilteredCount(int filteredCount) {
+        this.filteredCount = filteredCount;
+    }
+
+    public int getItemCount() {
+        return itemCount;
+    }
+
+    public void setItemCount(int itemCount) {
+        this.itemCount = itemCount;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getPageCount() {
+        return pageCount;
+    }
+
+    public void setPageCount(int pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/ChannelPagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ChannelPagination.java
@@ -1,0 +1,29 @@
+package com.rabbitmq.http.client.domain;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ChannelPagination extends AbstractPagination {
+    private ChannelInfo[] items;
+
+    public ChannelPagination() {
+        super();
+    }
+
+    public ChannelPagination(ChannelInfo[] items) {
+        super(items != null ? items.length : 0);
+        this.items = items;
+    }
+
+    public ChannelInfo[] getItems() {
+        return items;
+    }
+
+    public List<ChannelInfo> getItemsAsList() {
+        return Arrays.asList(items);
+    }
+
+    public void setItems(ChannelInfo[] items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/ConnectionPagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ConnectionPagination.java
@@ -1,0 +1,29 @@
+package com.rabbitmq.http.client.domain;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ConnectionPagination extends AbstractPagination {
+    private ConnectionInfo[] items;
+
+    public ConnectionPagination() {
+        super();
+    }
+
+    public ConnectionPagination(ConnectionInfo[] items) {
+        super(items != null ? items.length : 0);
+        this.items = items;
+    }
+
+    public ConnectionInfo[] getItems() {
+        return items;
+    }
+
+    public List<ConnectionInfo> getItemsAsList() {
+        return Arrays.asList(items);
+    }
+
+    public void setItems(ConnectionInfo[] items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/ExchangePagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ExchangePagination.java
@@ -1,0 +1,29 @@
+package com.rabbitmq.http.client.domain;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ExchangePagination extends AbstractPagination {
+    private ExchangeInfo[] items;
+
+    public ExchangePagination() {
+        super();
+    }
+
+    public ExchangePagination(ExchangeInfo[] items) {
+        super(items != null ? items.length : 0);
+        this.items = items;
+    }
+
+    public ExchangeInfo[] getItems() {
+        return items;
+    }
+
+    public List<ExchangeInfo> getItemsAsList() {
+        return Arrays.asList(items);
+    }
+
+    public void setItems(ExchangeInfo[] items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/PageList.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/PageList.java
@@ -1,0 +1,4 @@
+package com.rabbitmq.http.client.domain;
+
+public class PageList {
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/QueryParameters.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueryParameters.java
@@ -1,0 +1,121 @@
+package com.rabbitmq.http.client.domain;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URIUtils;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class QueryParameters {
+
+    private Map<String,Object> parameters = new HashMap<>();
+    private Pagination pagination = new Pagination();
+    private Columns columns = new Columns();
+
+    public Pagination pagination() {
+        return pagination;
+    }
+    public Columns columns() {
+        return columns;
+    }
+
+    public QueryParameters clear() {
+        parameters.clear();
+        return this;
+    }
+
+    public boolean isEmpty() {
+        return parameters.isEmpty();
+    }
+
+
+    public URIBuilder appendToURI(URIBuilder builder) {
+        parameters.forEach((name, value) -> {
+            @SuppressWarnings("unchecked")
+            String valueAsString = value instanceof Collection ?
+                    String.join(",", (Iterable<String>)value) : String.valueOf(value);
+            builder.addParameter(name, valueAsString);
+
+        });
+        return builder;
+    }
+
+    public class Columns {
+        public Columns add(String name) {
+            @SuppressWarnings("unchecked")
+            Set<String> columns = (Set<String>)parameters.get("columns");
+            if (columns == null) {
+                columns = new HashSet<>();
+                parameters.put("columns", columns);
+            }
+            columns.add(name);
+            return this;
+        }
+        public Columns sort(String name) {
+            parameters.put("sort", name);
+            return this;
+        }
+        public Columns sortReverse(boolean sortReverse) {
+            parameters.put("sort_reverse", sortReverse);
+            return this;
+        }
+        public Columns clear() {
+            parameters.remove("columns");
+            parameters.remove("sort");
+            parameters.remove("sort_reverse");
+            return this;
+        }
+        public QueryParameters query() {
+            return QueryParameters.this;
+        }
+
+        public boolean hasAny() {
+            return parameters.containsKey("columns") || parameters.containsKey("sort") || parameters.containsKey("sort_reverse");
+        }
+    }
+
+    public class Pagination {
+
+        public Pagination setName(String name) {
+            setName(name, false);
+            return this;
+        }
+        public Pagination setName(String name, boolean usesRegex) {
+            parameters.put("name", name);
+            parameters.put("use_regex", usesRegex);
+            setFirstPageIfNotSet();
+            return this;
+        }
+        public Pagination setPageSize(int pageSize) {
+            parameters.put("page_size", pageSize);
+            setFirstPageIfNotSet();
+
+            return this;
+        }
+        private void setFirstPageIfNotSet() {
+            parameters.putIfAbsent("page", 1);
+        }
+
+        public Pagination nextPage(AbstractPagination pagination) {
+            parameters.put("page", pagination.getPage()+1);
+            return this;
+        }
+        public Pagination clear() {
+            parameters.remove("name");
+            parameters.remove("use_regex");
+            parameters.remove("page_size");
+            parameters.remove("page");
+            return this;
+        }
+
+        public QueryParameters query() {
+            return QueryParameters.this;
+        }
+
+        public boolean hasAny() {
+            return parameters.containsKey("name") || parameters.containsKey("page_size") || parameters.containsKey("page");
+        }
+
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/QueuePagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueuePagination.java
@@ -1,6 +1,8 @@
 package com.rabbitmq.http.client.domain;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 public class QueuePagination extends AbstractPagination {
     private QueueInfo[] items;
@@ -16,6 +18,10 @@ public class QueuePagination extends AbstractPagination {
 
     public QueueInfo[] getItems() {
         return items;
+    }
+
+    public List<QueueInfo> getItemsAsList() {
+        return Arrays.asList(items);
     }
 
     public void setItems(QueueInfo[] items) {

--- a/src/main/java/com/rabbitmq/http/client/domain/QueuePagination.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueuePagination.java
@@ -1,0 +1,24 @@
+package com.rabbitmq.http.client.domain;
+
+import java.util.Collection;
+
+public class QueuePagination extends AbstractPagination {
+    private QueueInfo[] items;
+
+    public QueuePagination() {
+        super();
+    }
+
+    public QueuePagination(QueueInfo[] items) {
+        super(items != null ? items.length : 0);
+        this.items = items;
+    }
+
+    public QueueInfo[] getItems() {
+        return items;
+    }
+
+    public void setItems(QueueInfo[] items) {
+        this.items = items;
+    }
+}

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -832,6 +832,7 @@ class ClientSpec extends Specification {
     client << clients()
   }
 
+
   @Unroll
   def "PUT /api/policies/{vhost}/{name}"() {
     given: "vhost / and definition"

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -699,6 +699,29 @@ class ClientSpec extends Specification {
   }
 
   @Unroll
+  def "GET /api/queues with paging"() {
+    given: "at least one queue was declared"
+    Connection conn = cf.newConnection()
+    Channel ch = conn.createChannel()
+    String q = ch.queueDeclare().queue
+
+    when: "client lists queues"
+    def queryParameters = new QueryParameters().pagination().setPageSize(10).query();
+    def pagedXs = client.getQueues(queryParameters)
+
+    then: "a list of paged queues is returned"
+    def x = pagedXs.itemsAsList.first();
+    verifyQueueInfo(x)
+
+    cleanup:
+    ch.queueDelete(q)
+    conn.close()
+
+    where:
+    client << clients()
+  }
+
+  @Unroll
   def "GET /api/queues/{vhost} when vhost exists"() {
     given: "at least one queue was declared in vhost /"
     Connection conn = cf.newConnection()
@@ -2812,6 +2835,11 @@ class ClientSpec extends Specification {
     assert x.durable != null
     assert x.exclusive != null
     assert x.autoDelete != null
+  }
+  protected static void verifyQueuePagination(QueuePagination x, int expectedPage, int expectedPageCount) {
+    assert x.page == expectedPage
+    assert x.pageCount == expectedPageCount
+    assert x.itemCount == x.items.length
   }
 
   static boolean isVersion36orLater(String currentVersion) {


### PR DESCRIPTION
RabbitMQ Management API supports column selection, sorting, name-based filtering and paging. I need the majority of these features to get queues, specially paging. For completeness, i have decided to do it for the rest of the endpoints that support paging which are exchanges, channels and connections.

There is only one test case that verifies paging. 

I had to use Apache URIBuilder because Spring URI encoder class was not properly encoding regular expressions. For instance, characters such as `+`or `$` or parenthesis were not encoded.
