### PR TITLE
Retrieve exchanges & queues with paging

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -534,7 +534,7 @@ public class Client {
   }
 
   public ExchangePagination getExchanges(QueryParameters queryParameters) {
-    final URI uri = uriWithPath("./exchange/", queryParameters);
+    final URI uri = uriWithPath("./exchanges/", queryParameters);
     return (queryParameters.pagination().hasAny()) ? this.rt.getForObject(uri, ExchangePagination.class) :
             new ExchangePagination(this.rt.getForObject(uri, ExchangeInfo[].class));
   }
@@ -543,6 +543,12 @@ public class Client {
     final URI uri = uriWithPath("./exchanges/" + encodePathSegment(vhost));
     final ExchangeInfo[] result = this.getForObjectReturningNullOn404(uri, ExchangeInfo[].class);
     return asListOrNull(result);
+  }
+
+  public ExchangePagination getExchanges(String vhost, QueryParameters queryParameters) {
+    final URI uri = uriWithPath("./exchanges/" + encodePathSegment(vhost), queryParameters);
+    return (queryParameters.pagination().hasAny()) ? this.rt.getForObject(uri, ExchangePagination.class) :
+            new ExchangePagination(this.rt.getForObject(uri, ExchangeInfo[].class));
   }
 
   public ExchangeInfo getExchange(String vhost, String name) {
@@ -604,6 +610,12 @@ public class Client {
     final URI uri = uriWithPath("./queues/" + encodePathSegment(vhost));
     final QueueInfo[] result = this.getForObjectReturningNullOn404(uri, QueueInfo[].class);
     return asListOrNull(result);
+  }
+
+  public QueuePagination getQueues(String vhost, QueryParameters queryParameters) {
+    final URI uri = uriWithPath("./queues/" + encodePathSegment(vhost), queryParameters);
+    return (queryParameters.pagination().hasAny()) ? this.rt.getForObject(uri, QueuePagination.class) :
+            new QueuePagination(this.rt.getForObject(uri, QueueInfo[].class));
   }
 
   public QueueInfo getQueue(String vhost, String name) {

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -491,6 +491,23 @@ class ClientSpec extends Specification {
   }
 
   @Unroll
+  def "GET /api/exchanges with paging"() {
+    given: "at least one exchange was declared"
+    Connection conn = cf.newConnection()
+
+    when: "client lists exchanges"
+    def queryParameters = new QueryParameters().pagination().setPageSize(10).query();
+    def pagedXs = client.getExchanges("/", queryParameters)
+
+    then: "a list of paged exchanges is returned"
+    def x = pagedXs.itemsAsList.find { (it.name == "amq.fanout") }
+    verifyExchangeInfo(x)
+
+    where:
+    client << clients()
+  }
+
+  @Unroll
   def "GET /api/exchanges/{vhost} when vhost exists"() {
     when: "client retrieves the list of exchanges in a particular vhost"
     def xs = client.getExchanges("/")


### PR DESCRIPTION
Across any vhost and from one vhost. 
Fix issue with getExchanges which was using the wrong endpoint `/exchange` rather than `/exchnges`