### PR TITLE
Add support for details objects querying in queue requests

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -633,27 +633,26 @@ public class Client {
   }
 
   public List<QueueInfo> getQueues() {
-    final URI uri = uriWithPath("./queues/");
-    return Arrays.asList(this.httpLayer.get(uri, QueueInfo[].class));
+    return this.getQueues((DetailsParameters) null);
   }
 
   public List<QueueInfo> getQueues(DetailsParameters detailsParameters) {
     final URI uri = uri().withEncodedPath("./queues")
-        .withQueryParameters(detailsParameters.parameters())
+        .withQueryParameters(detailsParameters == null ? Collections.emptyMap() :
+            detailsParameters.parameters())
         .get();
     return Arrays.asList(this.httpLayer.get(uri, QueueInfo[].class));
   }
 
   public List<QueueInfo> getQueues(String vhost) {
-    final URI uri = uri().withEncodedPath("./queues").withPath(vhost).get();
-    final QueueInfo[] result = this.getForObjectReturningNullOn404(uri, QueueInfo[].class);
-    return asListOrNull(result);
+    return this.getQueues(vhost, (DetailsParameters) null);
   }
 
   public List<QueueInfo> getQueues(String vhost, DetailsParameters detailsParameters) {
     final URI uri = uri().withEncodedPath("./queues")
         .withPath(vhost)
-        .withQueryParameters(detailsParameters.parameters())
+        .withQueryParameters(detailsParameters == null ? Collections.emptyMap() :
+            detailsParameters.parameters())
         .get();
     final QueueInfo[] result = this.getForObjectReturningNullOn404(uri, QueueInfo[].class);
     return asListOrNull(result);
@@ -675,14 +674,14 @@ public class Client {
     final URI uri = uri().withEncodedPath("./queues")
         .withPath(vhost)
         .withPath(name)
-        .withQueryParameters(detailsParameters.parameters())
+        .withQueryParameters(detailsParameters == null ? Collections.emptyMap() :
+            detailsParameters.parameters())
         .get();
     return this.getForObjectReturningNullOn404(uri, QueueInfo.class);
   }
 
   public QueueInfo getQueue(String vhost, String name) {
-    final URI uri = uri().withEncodedPath("./queues").withPath(vhost).withPath(name).get();
-    return this.getForObjectReturningNullOn404(uri, QueueInfo.class);
+    return getQueue(vhost, name, null);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -637,8 +637,24 @@ public class Client {
     return Arrays.asList(this.httpLayer.get(uri, QueueInfo[].class));
   }
 
+  public List<QueueInfo> getQueues(DetailsParameters detailsParameters) {
+    final URI uri = uri().withEncodedPath("./queues")
+        .withQueryParameters(detailsParameters.parameters())
+        .get();
+    return Arrays.asList(this.httpLayer.get(uri, QueueInfo[].class));
+  }
+
   public List<QueueInfo> getQueues(String vhost) {
     final URI uri = uri().withEncodedPath("./queues").withPath(vhost).get();
+    final QueueInfo[] result = this.getForObjectReturningNullOn404(uri, QueueInfo[].class);
+    return asListOrNull(result);
+  }
+
+  public List<QueueInfo> getQueues(String vhost, DetailsParameters detailsParameters) {
+    final URI uri = uri().withEncodedPath("./queues")
+        .withPath(vhost)
+        .withQueryParameters(detailsParameters.parameters())
+        .get();
     final QueueInfo[] result = this.getForObjectReturningNullOn404(uri, QueueInfo[].class);
     return asListOrNull(result);
   }
@@ -653,6 +669,15 @@ public class Client {
     } else {
       return new Page(this.httpLayer.get(uri, QueueInfo[].class));
     }
+  }
+
+  public QueueInfo getQueue(String vhost, String name, DetailsParameters detailsParameters) {
+    final URI uri = uri().withEncodedPath("./queues")
+        .withPath(vhost)
+        .withPath(name)
+        .withQueryParameters(detailsParameters.parameters())
+        .get();
+    return this.getForObjectReturningNullOn404(uri, QueueInfo.class);
   }
 
   public QueueInfo getQueue(String vhost, String name) {

--- a/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
+++ b/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
@@ -479,27 +479,33 @@ public class ReactorNettyClient {
     }
 
     public Flux<QueueInfo> getQueues() {
-        return doGetFlux(QueueInfo.class, "queues");
+        return getQueues((DetailsParameters) null);
     }
 
     public Flux<QueueInfo> getQueues(DetailsParameters detailsParameters) {
-        return doGetFlux(QueueInfo.class, detailsParameters.parameters(), "queues");
+        return doGetFlux(QueueInfo.class,
+            detailsParameters == null ? Collections.emptyMap() : detailsParameters.parameters(),
+            "queues");
     }
 
     public Flux<QueueInfo> getQueues(String vhost) {
-        return doGetFlux(QueueInfo.class, "queues", encodePath(vhost));
+        return getQueues(vhost, null);
     }
 
     public Flux<QueueInfo> getQueues(String vhost, DetailsParameters detailsParameters) {
-        return doGetFlux(QueueInfo.class, detailsParameters.parameters(), "queues", encodePath(vhost));
+        return doGetFlux(QueueInfo.class,
+            detailsParameters == null ? Collections.emptyMap() : detailsParameters.parameters(),
+            "queues", encodePath(vhost));
     }
 
     public Mono<QueueInfo> getQueue(String vhost, String name, DetailsParameters detailsParameters) {
-        return doGetMono(QueueInfo.class, detailsParameters.parameters(), "queues", encodePath(vhost), encodePath(name));
+        return doGetMono(QueueInfo.class,
+            detailsParameters == null ? Collections.emptyMap() : detailsParameters.parameters(),
+            "queues", encodePath(vhost), encodePath(name));
     }
 
     public Mono<QueueInfo> getQueue(String vhost, String name) {
-        return doGetMono(QueueInfo.class, "queues", encodePath(vhost), encodePath(name));
+        return this.getQueue(vhost, name, null);
     }
 
     public Mono<HttpResponse> declareQueue(String vhost, String name, QueueInfo info) {

--- a/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
+++ b/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -482,8 +482,20 @@ public class ReactorNettyClient {
         return doGetFlux(QueueInfo.class, "queues");
     }
 
+    public Flux<QueueInfo> getQueues(DetailsParameters detailsParameters) {
+        return doGetFlux(QueueInfo.class, detailsParameters.parameters(), "queues");
+    }
+
     public Flux<QueueInfo> getQueues(String vhost) {
         return doGetFlux(QueueInfo.class, "queues", encodePath(vhost));
+    }
+
+    public Flux<QueueInfo> getQueues(String vhost, DetailsParameters detailsParameters) {
+        return doGetFlux(QueueInfo.class, detailsParameters.parameters(), "queues", encodePath(vhost));
+    }
+
+    public Mono<QueueInfo> getQueue(String vhost, String name, DetailsParameters detailsParameters) {
+        return doGetMono(QueueInfo.class, detailsParameters.parameters(), "queues", encodePath(vhost), encodePath(name));
     }
 
     public Mono<QueueInfo> getQueue(String vhost, String name) {
@@ -852,10 +864,20 @@ public class ReactorNettyClient {
     }
 
     private <T> Mono<T> doGetMono(Class<T> type, String... pathSegments) {
+       return doGetMono(type, null, pathSegments);
+    }
+
+    private <T> Mono<T> doGetMono(Class<T> type, Map<String, String> queryParameters, String... pathSegments) {
+        String uri = uri(pathSegments);
+        if (queryParameters != null && !queryParameters.isEmpty()) {
+            uri += queryParameters.entrySet().stream()
+                .map(e -> String.format("%s=%s", e.getKey(), encodeHttpParameter(e.getValue())))
+                .collect(Collectors.joining("&", "?", ""));
+        }
         return Mono.from(client
                 .headersWhen(authorizedHeader())
                 .get()
-                .uri(uri(pathSegments))
+                .uri(uri)
                 .response(decode(type)));
     }
 
@@ -880,9 +902,14 @@ public class ReactorNettyClient {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private <T> Flux<T> doGetFlux(Class<T> type, String... pathSegments) {
-        return (Flux<T>) doGetMono(Array.newInstance(type, 0).getClass(), pathSegments).flatMapMany(items -> Flux.fromArray((Object[]) items));
+        return doGetFlux(type, null, pathSegments);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Flux<T> doGetFlux(Class<T> type, Map<String, String> queryParameters, String... pathSegments) {
+        return (Flux<T>) doGetMono(Array.newInstance(type, 0).getClass(), queryParameters, pathSegments)
+            .flatMapMany(items -> Flux.fromArray((Object[]) items));
     }
 
     protected Function<? super HttpHeaders, Mono<? extends HttpHeaders>> authorizedHeader() {

--- a/src/main/java/com/rabbitmq/http/client/domain/DetailsParameters.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/DetailsParameters.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rabbitmq.http.client.domain;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A class to gather parameters on <code>_details</code> objects.
+ *
+ * <p>Parameters can be set to get extra information on how count fields have changed (messages sent
+ * and received, queue lengths).
+ *
+ * <p>A {@link DetailsParameters} instance can wrap a {@link QueryParameters} and return it with its
+ * own parameters applied on it, see {@link #DetailsParameters(QueryParameters)} and {@link
+ * #withQueryParameters()}. This way {@link DetailsParameters} can be "injected" in methods like
+ * {@link com.rabbitmq.http.client.Client#getQueues(DetailsParameters)}.
+ *
+ * @since 4.1.0
+ * @see com.rabbitmq.http.client.Client#getQueues(DetailsParameters)
+ * @see com.rabbitmq.http.client.Client#getQueues(QueryParameters)
+ * @see com.rabbitmq.http.client.Client#getQueue(String, String, DetailsParameters)
+ * @see com.rabbitmq.http.client.ReactorNettyClient#getQueues(String, DetailsParameters)
+ * @see com.rabbitmq.http.client.ReactorNettyClient#getQueue(String, String, DetailsParameters)
+ */
+public class DetailsParameters {
+
+  private final Map<String, String> parameters = new HashMap<>();
+  private final QueryParameters queryParameters;
+
+  public DetailsParameters() {
+    this(null);
+  }
+
+  public DetailsParameters(QueryParameters queryParameters) {
+    this.queryParameters = queryParameters;
+  }
+
+  private static void checkGreaterThanZero(int value, String field) {
+    if (value <= 0) {
+      throw new IllegalArgumentException(String.format("'%s' must be greater than 0", field));
+    }
+  }
+
+  private static void checkGreaterThanZero(Duration value, String field) {
+    if (value == null) {
+      throw new IllegalArgumentException(String.format("'%s' cannot be null", field));
+    }
+    if (value.toSeconds() <= 0) {
+      throw new IllegalArgumentException(String.format("'%s' must be greater than 0", field));
+    }
+  }
+
+  public DetailsParameters messageRates(int ageSeconds, int incrementSeconds) {
+    checkGreaterThanZero(ageSeconds, "age");
+    checkGreaterThanZero(incrementSeconds, "increment");
+    this.parameters.put("msg_rates_age", String.valueOf(ageSeconds));
+    this.parameters.put("msg_rates_incr", String.valueOf(incrementSeconds));
+    return this;
+  }
+
+  public DetailsParameters messageRates(Duration age, Duration increment) {
+    checkGreaterThanZero(age, "age");
+    checkGreaterThanZero(increment, "increment");
+    return this.messageRates((int) age.toSeconds(), (int) increment.toSeconds());
+  }
+
+  public DetailsParameters lengths(int ageSeconds, int incrementSeconds) {
+    checkGreaterThanZero(ageSeconds, "age");
+    checkGreaterThanZero(incrementSeconds, "increment");
+    this.parameters.put("lengths_age", String.valueOf(ageSeconds));
+    this.parameters.put("lengths_incr", String.valueOf(incrementSeconds));
+    return this;
+  }
+
+  public DetailsParameters lengths(Duration age, Duration increment) {
+    checkGreaterThanZero(age, "age");
+    checkGreaterThanZero(increment, "increment");
+    return this.lengths((int) age.toSeconds(), (int) increment.toSeconds());
+  }
+
+  public Map<String, String> parameters() {
+    return new HashMap<>(parameters);
+  }
+
+  public QueryParameters withQueryParameters() {
+    if (this.queryParameters == null) {
+      throw new IllegalStateException("No query parameters");
+    }
+    this.parameters.forEach((k, v) -> this.queryParameters.parameter(k, v));
+    return this.queryParameters;
+  }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/DetailsParameters.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/DetailsParameters.java
@@ -19,6 +19,8 @@ package com.rabbitmq.http.client.domain;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * A class to gather parameters on <code>_details</code> objects.
@@ -26,10 +28,10 @@ import java.util.Map;
  * <p>Parameters can be set to get extra information on how count fields have changed (messages sent
  * and received, queue lengths).
  *
- * <p>A {@link DetailsParameters} instance can wrap a {@link QueryParameters} and return it with its
- * own parameters applied on it, see {@link #DetailsParameters(QueryParameters)} and {@link
- * #withQueryParameters()}. This way {@link DetailsParameters} can be "injected" in methods like
- * {@link com.rabbitmq.http.client.Client#getQueues(DetailsParameters)}.
+ * <p>A {@link DetailsParameters} instance can create a {@link QueryParameters} instance with its
+ * own parameters applied on it, see {@link #queryParameters()}. This way {@link DetailsParameters}
+ * can be "injected" in methods like {@link
+ * com.rabbitmq.http.client.Client#getQueues(DetailsParameters)}.
  *
  * @since 4.1.0
  * @see com.rabbitmq.http.client.Client#getQueues(DetailsParameters)
@@ -40,16 +42,8 @@ import java.util.Map;
  */
 public class DetailsParameters {
 
-  private final Map<String, String> parameters = new HashMap<>();
-  private final QueryParameters queryParameters;
-
-  public DetailsParameters() {
-    this(null);
-  }
-
-  public DetailsParameters(QueryParameters queryParameters) {
-    this.queryParameters = queryParameters;
-  }
+  private final Map<String, Object> parameters = new HashMap<>();
+  private QueryParameters queryParameters;
 
   private static void checkGreaterThanZero(int value, String field) {
     if (value <= 0) {
@@ -95,14 +89,14 @@ public class DetailsParameters {
   }
 
   public Map<String, String> parameters() {
-    return new HashMap<>(parameters);
+    return this.parameters.entrySet().stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().toString()));
   }
 
-  public QueryParameters withQueryParameters() {
+  public QueryParameters queryParameters() {
     if (this.queryParameters == null) {
-      throw new IllegalStateException("No query parameters");
+      this.queryParameters = new QueryParameters(this.parameters);
     }
-    this.parameters.forEach((k, v) -> this.queryParameters.parameter(k, v));
     return this.queryParameters;
   }
 }

--- a/src/main/java/com/rabbitmq/http/client/domain/QueryParameters.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueryParameters.java
@@ -27,9 +27,17 @@ import java.util.function.BiFunction;
 
 public class QueryParameters {
 
-  private final Map<String, Object> parameters = new HashMap<>();
+  private final Map<String, Object> parameters;
   private final Pagination pagination = new Pagination();
   private final Columns columns = new Columns();
+
+  public QueryParameters() {
+    this(new HashMap<>());
+  }
+
+  QueryParameters(Map<String, Object> parameters) {
+    this.parameters = parameters;
+  }
 
   public Pagination pagination() {
     return pagination;

--- a/src/main/java/com/rabbitmq/http/client/domain/QueryParameters.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueryParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
-import org.apache.http.client.utils.URIBuilder;
 
 public class QueryParameters {
 
@@ -81,6 +79,11 @@ public class QueryParameters {
     );
   }
 
+  QueryParameters parameter(String field, Object value) {
+    this.parameters.put(field, value);
+    return this;
+  }
+
   public class Columns {
     public Columns add(String name) {
       @SuppressWarnings("unchecked")
@@ -119,6 +122,7 @@ public class QueryParameters {
           || parameters.containsKey("sort")
           || parameters.containsKey("sort_reverse");
     }
+
   }
 
   public class Pagination {

--- a/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/QueueInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -127,6 +127,8 @@ public class QueueInfo {
   private long totalPersistentMessages = -1;
   @JsonProperty("messages_ram")
   private long totalTransientMessages = -1;
+  @JsonProperty("messages_details")
+  private RateDetails messagesDetails;
   @JsonProperty("messages_ready")
   private long messagesReady = -1;
   @JsonProperty("messages_ready_details")
@@ -378,6 +380,14 @@ public class QueueInfo {
 
   public void setMessagesReady(long messagesReady) {
     this.messagesReady = messagesReady;
+  }
+
+  public RateDetails getMessagesDetails() {
+    return messagesDetails;
+  }
+
+  public void setMessagesDetails(RateDetails messagesDetails) {
+    this.messagesDetails = messagesDetails;
   }
 
   public RateDetails getMessagesReadyDetails() {

--- a/src/main/java/com/rabbitmq/http/client/domain/RateDetails.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/RateDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,22 +17,54 @@
 package com.rabbitmq.http.client.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
 
 public class RateDetails {
+  private final double average;
+  private final double averageRate;
   private final double rate;
+  private final List<Sample> samples;
 
-  public RateDetails(@JsonProperty("rate") double rate) {
+  public RateDetails(double rate) {
+    this(0, 0, rate, Collections.emptyList());
+  }
+
+  public RateDetails(
+      @JsonProperty("avg") double average,
+      @JsonProperty("avg_rate") double averageRate,
+      @JsonProperty("rate") double rate,
+      @JsonProperty("samples") List<Sample> samples
+      ) {
+    this.average = average;
+    this.averageRate = averageRate;
     this.rate = rate;
+    this.samples = samples;
+  }
+
+  public double getAverage() {
+    return average;
+  }
+
+  public double getAverageRate() {
+    return averageRate;
   }
 
   public double getRate() {
     return rate;
   }
 
+  public List<Sample> getSamples() {
+    return samples;
+  }
+
   @Override
   public String toString() {
     return "RateDetails{" +
-        "rate=" + rate +
+        "average=" + average +
+        ", averageRate=" + averageRate +
+        ", rate=" + rate +
+        ", samples=" + samples +
         '}';
   }
 }

--- a/src/main/java/com/rabbitmq/http/client/domain/Sample.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/Sample.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rabbitmq.http.client.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ *
+ */
+public class Sample {
+
+  private final long sample;
+  private final long timestamp;
+
+  public Sample(@JsonProperty("sample") long sample,
+      @JsonProperty("timestamp") long timestamp) {
+    this.sample = sample;
+    this.timestamp = timestamp;
+  }
+
+  public long getSample() {
+    return sample;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public String toString() {
+    return "Sample{" +
+        "sample=" + sample +
+        ", timestamp=" + timestamp +
+        '}';
+  }
+}

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -927,14 +927,15 @@ class ClientSpec extends Specification {
     executorService.submit(publishing)
 
     when: "client lists queues with details"
-    def queryParameters = new DetailsParameters(new QueryParameters()
-            .name("^queue-for-paging-and-details-test-*", true)
-            .pagination()
-            .pageSize(10)
-            .query())
-            .messageRates(60, 5)
-            .lengths(60, 5)
-            .withQueryParameters()
+    def queryParameters = new DetailsParameters()
+              .messageRates(60, 5)
+              .lengths(60, 5)
+            .queryParameters()
+              .name("^queue-for-paging-and-details-test-*", true)
+              .pagination()
+              .pageSize(10)
+            .query()
+
     def request = { client.getQueues(queryParameters) }
     waitAtMostUntilTrue(10, {
       def p = request()

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
@@ -101,7 +104,10 @@ class ClientSpec extends Specification {
   }
 
   def setup() {
-    def c = new Client(url(), DEFAULT_USERNAME, DEFAULT_PASSWORD)
+    def c = new Client(new ClientParameters()
+            .url(url())
+            .username(DEFAULT_USERNAME)
+            .password(DEFAULT_PASSWORD))
     c.getConnections().each { c.closeConnection(it.getName())}
     awaitAllConnectionsClosed(c)
     brokerVersion = c.getOverview().getServerVersion()
@@ -773,6 +779,56 @@ class ClientSpec extends Specification {
   }
 
   @Unroll
+  def "GET /api/queues with details"() {
+    given: "at least one queue was declared and some messages published"
+    Connection conn = cf.newConnection()
+    Channel ch = conn.createChannel()
+    String q = ch.queueDeclare().queue
+    ExecutorService executorService = Executors.newSingleThreadExecutor()
+    def publishing = {
+      while (!Thread.currentThread().isInterrupted()) {
+        ch.basicPublish("", q, null, "".getBytes(StandardCharsets.UTF_8))
+        try {
+          Thread.sleep(10)
+        } catch (InterruptedException e) {
+          return
+        }
+      }
+    }
+    executorService.submit(publishing)
+
+    when: "client lists queues with details"
+    def detailsParameters = new DetailsParameters()
+      .messageRates(60, 5)
+      .lengths(60, 5)
+    def request = { client.getQueues(detailsParameters)
+      .find({qi -> qi.name == q})}
+    waitAtMostUntilTrue(10, {
+      def qi = request()
+      qi.messagesDetails != null && qi.messagesDetails.rate > 0
+    })
+    def x = request()
+
+    then: "a list of queues with details is returned"
+    verifyQueueInfo(x)
+    x.getMessagesDetails() != null
+    x.getMessagesDetails().getAverage() > 0
+    x.getMessagesDetails().getAverageRate() > 0
+    x.getMessagesDetails().getRate() > 0
+    x.getMessagesDetails().getSamples().size() > 0
+    x.getMessagesDetails().getSamples().get(0).getSample() > 0
+    x.getMessagesDetails().getSamples().get(0).getTimestamp() > 0
+
+    cleanup:
+    executorService.shutdownNow()
+    ch.queueDelete(q)
+    conn.close()
+
+    where:
+    client << clients()
+  }
+
+  @Unroll
   def "GET /api/queues with paging"() {
     given: "at least one queue was declared"
     Connection conn = cf.newConnection()
@@ -838,6 +894,73 @@ class ClientSpec extends Specification {
     verifyQueueInfo(x)
 
     cleanup:
+    queues.forEach { ch.queueDelete(it) }
+    conn.close()
+
+    where:
+    client << clients()
+  }
+
+  @Unroll
+  def "GET /api/queues with paging and details"() {
+    given: "at least one queue was declared"
+    Connection conn = cf.newConnection()
+    Channel ch = conn.createChannel()
+    def queues = (0..15).collect {it ->
+      def q = "queue-for-paging-and-details-test-" + it
+      ch.queueDeclare(q, false, false, false, null)
+      ch.queueBind(q, "amq.fanout", "")
+      q
+    }
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor()
+    def publishing = {
+      while (!Thread.currentThread().isInterrupted()) {
+        ch.basicPublish("amq.fanout", "", null, "".getBytes(StandardCharsets.UTF_8))
+        try {
+          Thread.sleep(10)
+        } catch (InterruptedException e) {
+          return
+        }
+      }
+    }
+    executorService.submit(publishing)
+
+    when: "client lists queues with details"
+    def queryParameters = new DetailsParameters(new QueryParameters()
+            .name("^queue-for-paging-and-details-test-*", true)
+            .pagination()
+            .pageSize(10)
+            .query())
+            .messageRates(60, 5)
+            .lengths(60, 5)
+            .withQueryParameters()
+    def request = { client.getQueues(queryParameters) }
+    waitAtMostUntilTrue(10, {
+      def p = request()
+      p.filteredCount == queues.size() && p.items[0].messagesDetails != null
+        && p.items[0].messagesDetails.rate > 0
+    })
+    def page = request()
+
+    then: "a list of paged queues with details is returned"
+    page.filteredCount == queues.size()
+    page.itemCount == 10
+    page.pageCount == 2
+    page.totalCount >= page.filteredCount
+    page.page == 1
+    def x = page.itemsAsList.first();
+    verifyQueueInfo(x)
+    x.getMessagesDetails() != null
+    x.getMessagesDetails().getAverage() > 0
+    x.getMessagesDetails().getAverageRate() > 0
+    x.getMessagesDetails().getRate() > 0
+    x.getMessagesDetails().getSamples().size() > 0
+    x.getMessagesDetails().getSamples().get(0).getSample() > 0
+    x.getMessagesDetails().getSamples().get(0).getTimestamp() > 0
+
+    cleanup:
+    executorService.shutdownNow()
     queues.forEach { ch.queueDelete(it) }
     conn.close()
 
@@ -922,6 +1045,72 @@ class ClientSpec extends Specification {
     x.exclusive
 
     cleanup:
+    ch.queueDelete(q)
+    conn.close()
+
+    where:
+    client << clients()
+  }
+
+  @Unroll
+  def "GET /api/queues/{name} with details"() {
+    given: "at least one queue was declared and some messages published"
+    ExecutorService executorService = Executors.newSingleThreadExecutor()
+    Connection conn = cf.newConnection()
+    Channel ch = conn.createChannel()
+    String q = ch.queueDeclare().queue
+    def publishing = {
+      while (!Thread.currentThread().isInterrupted()) {
+        ch.basicPublish("", q, null, "".getBytes(StandardCharsets.UTF_8))
+        try {
+          Thread.sleep(10)
+        } catch (InterruptedException e) {
+          return
+        }
+      }
+    }
+    executorService.submit(publishing)
+
+    when: "client get queue with details"
+    def request = { client.getQueue("/", q, new DetailsParameters()
+            .messageRates(60, 5)
+            .lengths(60, 5))}
+    waitAtMostUntilTrue(10, {
+      def qi = request()
+      qi.getMessagesDetails() != null && qi.getMessagesDetails().getRate() > 0
+    })
+    def x = request()
+
+    then: "the queue with details info is returned"
+    verifyQueueInfo(x)
+    x.getMessagesDetails() != null
+    x.getMessagesDetails().getAverage() > 0
+    x.getMessagesDetails().getAverageRate() > 0
+    x.getMessagesDetails().getRate() > 0
+    x.getMessagesDetails().getSamples().size() > 0
+    x.getMessagesDetails().getSamples().get(0).getSample() > 0
+    x.getMessagesDetails().getSamples().get(0).getTimestamp() > 0
+
+    x.getMessagesReadyDetails() != null
+    x.getMessagesReadyDetails().getAverage() > 0
+    x.getMessagesReadyDetails().getAverageRate() > 0
+    x.getMessagesReadyDetails().getRate() > 0
+    x.getMessagesReadyDetails().getSamples().size() > 0
+    x.getMessagesReadyDetails().getSamples().get(0).getSample() > 0
+    x.getMessagesReadyDetails().getSamples().get(0).getTimestamp() > 0
+
+    x.getMessagesUnacknowledgedDetails() != null
+
+    x.getMessageStats() != null
+    x.getMessageStats().getBasicPublishDetails().getAverage() > 0
+    x.getMessageStats().getBasicPublishDetails().getAverageRate() > 0
+    x.getMessageStats().getBasicPublishDetails().getRate() > 0
+    x.getMessageStats().getBasicPublishDetails().getSamples().size() > 0
+    x.getMessageStats().getBasicPublishDetails().getSamples().get(0).getSample() > 0
+    x.getMessageStats().getBasicPublishDetails().getSamples().get(0).getTimestamp() > 0
+
+    cleanup:
+    executorService.shutdown()
     ch.queueDelete(q)
     conn.close()
 


### PR DESCRIPTION
This commit introduces the DetailsParameters class to
query _details objects in the API. For now only queue-related
queries are supported.

The DetailsParameters class allows to set the msg_rates_age and
msg_rates_incr parameters (for messages rates) and the lengths_age
and lengths_incr parameters (for queue lengths). When set up,
information on how count fields have changed is provided (rates and
samples).

Fixes #118