### PR TITLE
Add getter and setter to ExchangeInfo messageStats Dto

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/domain/ExchangeInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/ExchangeInfo.java
@@ -103,6 +103,14 @@ public class ExchangeInfo {
     this.arguments = arguments;
   }
 
+  public ExchangeMessageStats getMessageStats() {
+    return messageStats;
+  }
+
+  public void setMessageStats(ExchangeMessageStats messageStats) {
+    this.messageStats = messageStats;
+  }
+
   @Override
   public String toString() {
     return "ExchangeInfo{" +


### PR DESCRIPTION
When doing a get for rabbitmq exchanges in the client we receive ExchangeInfo.
This is good and comprehensive dto object with lots of information.

However in my particular case I need to access ExchangeMessageStats for some more insights.
But for some reason messageStats is a private field with no getter. ExchangeMessageStats is a public class so I assumed it to have public getter/setter inside ExchangeInfo as any other fields.

@pivotal-cla This is an Obvious Fix