### PR TITLE
Add global parameter mqtt-vhost mapping functions 

### DIFF
--- a/ci/before-build.sh
+++ b/ci/before-build.sh
@@ -36,6 +36,9 @@ $PLUGINS enable rabbitmq_shovel_management
 $PLUGINS enable rabbitmq_federation
 $PLUGINS enable rabbitmq_federation_management
 
+# Enable mqtt plugin
+$PLUGINS enable rabbitmq_mqtt
+
 # So that virtual host descriptions are available
 $CTL enable_feature_flag all
 

--- a/ci/start-broker.sh
+++ b/ci/start-broker.sh
@@ -13,7 +13,7 @@ wait_for_message() {
 
 mkdir -p rabbitmq-configuration
 
-echo "[rabbitmq_management, rabbitmq_shovel,rabbitmq_shovel_management,rabbitmq_federation,rabbitmq_federation_management]." \
+echo "[rabbitmq_management, rabbitmq_shovel,rabbitmq_shovel_management,rabbitmq_federation,rabbitmq_federation_management,rabbitmq_mqtt]." \
   > rabbitmq-configuration/enabled_plugins
 
 echo "Running RabbitMQ ${RABBITMQ_IMAGE}"

--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -1261,6 +1261,29 @@ public class Client {
     this.deleteIgnoring404(uri);
   }
 
+  public MqttVhostPortInfo getMqttVhostPorts(){
+    return getGlobalParameters("mqtt_port_to_vhost_mapping", new ParameterizedTypeReference<>() {});
+  }
+
+  public void deleteMqttVhostPorts() {
+    this.deleteIgnoring404(uri().withEncodedPath("./global-parameters/mqtt_port_to_vhost_mapping").get());
+  }
+
+  public void setMqttVhostPorts(Map<Integer, String> portMappings) {
+    for (String vhost : portMappings.values()){
+      if (vhost.isBlank()) {
+        throw new IllegalArgumentException("Map with undefined vhosts provided!");
+      }
+    }
+
+    final URI uri = uri().withEncodedPath("./global-parameters/mqtt_port_to_vhost_mapping").get();
+
+    MqttVhostPortInfo body = new MqttVhostPortInfo();
+    body.setValue(portMappings);
+
+    this.httpLayer.put(uri, body);
+  }
+
   private <T> List<T> getParameters(String component, final ParameterizedTypeReference<List<T>> responseType) {
     final URI uri = uri().withEncodedPath("./parameters").withEncodedPath(component).withPathSeparator().get();
     return this.httpLayer.get(uri, responseType);
@@ -1268,6 +1291,11 @@ public class Client {
 
   private <T> List<T> getParameters(String vhost, String component, final ParameterizedTypeReference<List<T>> responseType) {
     final URI uri = uri().withEncodedPath("./parameters").withEncodedPath(component).withPath(vhost).get();
+    return getForObjectReturningNullOn404(uri, responseType);
+  }
+
+  private <T> T getGlobalParameters(String name, final ParameterizedTypeReference<T> responseType) {
+    final URI uri = uri().withEncodedPath("./global-parameters").withEncodedPath(name).withPathSeparator().get();
     return getForObjectReturningNullOn404(uri, responseType);
   }
 

--- a/src/main/java/com/rabbitmq/http/client/Client.java
+++ b/src/main/java/com/rabbitmq/http/client/Client.java
@@ -1261,15 +1261,15 @@ public class Client {
     this.deleteIgnoring404(uri);
   }
 
-  public MqttVhostPortInfo getMqttVhostPorts(){
+  public MqttVhostPortInfo getMqttPortToVhostMapping(){
     return getGlobalParameters("mqtt_port_to_vhost_mapping", new ParameterizedTypeReference<>() {});
   }
 
-  public void deleteMqttVhostPorts() {
+  public void deleteMqttPortToVhostMapping() {
     this.deleteIgnoring404(uri().withEncodedPath("./global-parameters/mqtt_port_to_vhost_mapping").get());
   }
 
-  public void setMqttVhostPorts(Map<Integer, String> portMappings) {
+  public void setMqttPortToVhostMapping(Map<Integer, String> portMappings) {
     for (String vhost : portMappings.values()){
       if (vhost.isBlank()) {
         throw new IllegalArgumentException("Map with undefined vhosts provided!");

--- a/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
+++ b/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
@@ -814,15 +814,15 @@ public class ReactorNettyClient {
         return doGetFlux(UpstreamSetInfo.class, "parameters", "federation-upstream-set", encodePath(vhost));
     }
 
-    public Mono<MqttVhostPortInfo> getMqttVhostPorts(){
+    public Mono<MqttVhostPortInfo> getMqttPortToVhostMapping(){
         return doGetMono(MqttVhostPortInfo.class, "global-parameters", "mqtt_port_to_vhost_mapping");
     }
 
-    public Mono<HttpResponse> deleteMqttVhostPorts(){
+    public Mono<HttpResponse> deleteMqttPortToVhostMapping(){
         return doDelete( "global-parameters", "mqtt_port_to_vhost_mapping");
     }
 
-    public Mono<HttpResponse> setMqttVhostPorts(Map<Integer, String> portMappings){
+    public Mono<HttpResponse> setMqttPortToVhostMapping(Map<Integer, String> portMappings){
         for (String vhost : portMappings.values()){
             if (vhost.isBlank()) {
                 throw new IllegalArgumentException("Map with undefined vhosts provided!");

--- a/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
+++ b/src/main/java/com/rabbitmq/http/client/ReactorNettyClient.java
@@ -814,6 +814,27 @@ public class ReactorNettyClient {
         return doGetFlux(UpstreamSetInfo.class, "parameters", "federation-upstream-set", encodePath(vhost));
     }
 
+    public Mono<MqttVhostPortInfo> getMqttVhostPorts(){
+        return doGetMono(MqttVhostPortInfo.class, "global-parameters", "mqtt_port_to_vhost_mapping");
+    }
+
+    public Mono<HttpResponse> deleteMqttVhostPorts(){
+        return doDelete( "global-parameters", "mqtt_port_to_vhost_mapping");
+    }
+
+    public Mono<HttpResponse> setMqttVhostPorts(Map<Integer, String> portMappings){
+        for (String vhost : portMappings.values()){
+            if (vhost.isBlank()) {
+                throw new IllegalArgumentException("Map with undefined vhosts provided!");
+            }
+        }
+
+        MqttVhostPortInfo body = new MqttVhostPortInfo();
+        body.setValue(portMappings);
+        return doPut(body, "global-parameters", "mqtt_port_to_vhost_mapping");
+    }
+
+
     /**
      * Returns the limits (max queues and connections) for all virtual hosts.
      *

--- a/src/main/java/com/rabbitmq/http/client/domain/GlobalRuntimeParameter.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/GlobalRuntimeParameter.java
@@ -1,0 +1,33 @@
+package com.rabbitmq.http.client.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GlobalRuntimeParameter<T> {
+    private String name;
+    private T value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "RuntimeParameter{" +
+                "name='" + name + '\'' +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/src/main/java/com/rabbitmq/http/client/domain/MqttVhostPortInfo.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/MqttVhostPortInfo.java
@@ -1,0 +1,5 @@
+package com.rabbitmq.http.client.domain;
+
+import java.util.Map;
+
+public class MqttVhostPortInfo extends GlobalRuntimeParameter<Map<Integer, String>> {}

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -2843,6 +2843,44 @@ class ClientSpec extends Specification {
 
   }
 
+  def "GET /api/global-parameters/mqtt_port_to_vhost_mapping without mqtt vhost port mapping"() {
+    given: "rabbitmq deployment without mqtt port mappings defined"
+    client.deleteMqttVhostPorts()
+
+    when: "client tries to look up mqtt vhost port mappings"
+    def mqttPorts = client.getMqttVhostPorts()
+
+    then: "mqtt vhost port mappings are null"
+    mqttPorts == null
+  }
+
+  def "GET /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"() {
+    given: "a mqtt mapping with 2 vhosts defined"
+    def mqttInputMap = Map.of(2024, "vhost1", 2025, "vhost2")
+    client.setMqttVhostPorts(mqttInputMap)
+
+    when: "client tries to get mqtt port mappings"
+    def mqttInfo = client.getMqttVhostPorts()
+    def mqttReturnValues = mqttInfo.getValue()
+
+    then: "a map with 2 mqtt ports and vhosts is returned"
+    mqttReturnValues == mqttInputMap
+
+    cleanup:
+    client.deleteMqttVhostPorts()
+  }
+
+  def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"(){
+    given: "a mqtt mapping with blank vhost"
+    def mqttInputMap = Map.of(2024, " ", 2025, "vhost2")
+
+    when: "client tries to set mqtt port mappings"
+    client.setMqttVhostPorts(mqttInputMap)
+
+    then: "an illegal argument exception is thrown"
+    thrown(IllegalArgumentException)
+  }
+
   
   def "GET /api/vhost-limits/{vhost}"() {
     given: "a virtual host with limits"

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -2870,7 +2870,7 @@ class ClientSpec extends Specification {
     client.deleteMqttVhostPorts()
   }
 
-  def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"(){
+  def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a blank vhost value"(){
     given: "a mqtt mapping with blank vhost"
     def mqttInputMap = Map.of(2024, " ", 2025, "vhost2")
 

--- a/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ClientSpec.groovy
@@ -2845,10 +2845,10 @@ class ClientSpec extends Specification {
 
   def "GET /api/global-parameters/mqtt_port_to_vhost_mapping without mqtt vhost port mapping"() {
     given: "rabbitmq deployment without mqtt port mappings defined"
-    client.deleteMqttVhostPorts()
+    client.deleteMqttPortToVhostMapping()
 
     when: "client tries to look up mqtt vhost port mappings"
-    def mqttPorts = client.getMqttVhostPorts()
+    def mqttPorts = client.getMqttPortToVhostMapping()
 
     then: "mqtt vhost port mappings are null"
     mqttPorts == null
@@ -2857,17 +2857,17 @@ class ClientSpec extends Specification {
   def "GET /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"() {
     given: "a mqtt mapping with 2 vhosts defined"
     def mqttInputMap = Map.of(2024, "vhost1", 2025, "vhost2")
-    client.setMqttVhostPorts(mqttInputMap)
+    client.setMqttPortToVhostMapping(mqttInputMap)
 
     when: "client tries to get mqtt port mappings"
-    def mqttInfo = client.getMqttVhostPorts()
+    def mqttInfo = client.getMqttPortToVhostMapping()
     def mqttReturnValues = mqttInfo.getValue()
 
     then: "a map with 2 mqtt ports and vhosts is returned"
     mqttReturnValues == mqttInputMap
 
     cleanup:
-    client.deleteMqttVhostPorts()
+    client.deleteMqttPortToVhostMapping()
   }
 
   def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a blank vhost value"(){
@@ -2875,7 +2875,7 @@ class ClientSpec extends Specification {
     def mqttInputMap = Map.of(2024, " ", 2025, "vhost2")
 
     when: "client tries to set mqtt port mappings"
-    client.setMqttVhostPorts(mqttInputMap)
+    client.setMqttPortToVhostMapping(mqttInputMap)
 
     then: "an illegal argument exception is thrown"
     thrown(IllegalArgumentException)

--- a/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
@@ -2434,10 +2434,10 @@ class ReactorNettyClientSpec extends Specification {
 
     def "GET /api/global-parameters/mqtt_port_to_vhost_mapping without mqtt vhost port mapping"() {
         given: "rabbitmq deployment without mqtt port mappings defined"
-        client.deleteMqttVhostPorts().block();
+        client.deleteMqttPortToVhostMapping().block();
 
         when: "client tries to look up mqtt vhost port mappings"
-        def mqttPorts = client.getMqttVhostPorts().block();
+        def mqttPorts = client.getMqttPortToVhostMapping().block();
         then: "mono throws exception"
         def exception = thrown(HttpClientException.class)
         exception.status() == 404
@@ -2446,17 +2446,17 @@ class ReactorNettyClientSpec extends Specification {
     def "GET /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"() {
         given: "a mqtt mapping with 2 vhosts defined"
         def mqttInputMap = Map.of(2024, "vhost1", 2025, "vhost2")
-        client.setMqttVhostPorts(mqttInputMap).block()
+        client.setMqttPortToVhostMapping(mqttInputMap).block()
 
         when: "client tries to get mqtt port mappings"
-        def mqttInfo = client.getMqttVhostPorts().block()
+        def mqttInfo = client.getMqttPortToVhostMapping().block()
         def mqttReturnValues = mqttInfo.getValue()
 
         then: "a map with 2 mqtt ports and vhosts is returned"
         mqttReturnValues == mqttInputMap
 
         cleanup:
-        client.deleteMqttVhostPorts().block()
+        client.deleteMqttPortToVhostMapping().block()
     }
 
     def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a blank vhost value"(){
@@ -2464,7 +2464,7 @@ class ReactorNettyClientSpec extends Specification {
         def mqttInputMap = Map.of(2024, " ", 2025, "vhost2")
 
         when: "client tries to set mqtt port mappings"
-        client.setMqttVhostPorts(mqttInputMap).block()
+        client.setMqttPortToVhostMapping(mqttInputMap).block()
 
         then: "an illegal argument exception is thrown"
         thrown(IllegalArgumentException)

--- a/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
@@ -2431,6 +2431,45 @@ class ReactorNettyClientSpec extends Specification {
         client.clearMaxConnectionsLimit("/").block()
     }
 
+
+    def "GET /api/global-parameters/mqtt_port_to_vhost_mapping without mqtt vhost port mapping"() {
+        given: "rabbitmq deployment without mqtt port mappings defined"
+        client.deleteMqttVhostPorts().block();
+
+        when: "client tries to look up mqtt vhost port mappings"
+        def mqttPorts = client.getMqttVhostPorts().block();
+        then: "mono throws exception"
+        def exception = thrown(HttpClientException.class)
+        exception.status() == 404
+    }
+
+    def "GET /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"() {
+        given: "a mqtt mapping with 2 vhosts defined"
+        def mqttInputMap = Map.of(2024, "vhost1", 2025, "vhost2")
+        client.setMqttVhostPorts(mqttInputMap).block()
+
+        when: "client tries to get mqtt port mappings"
+        def mqttInfo = client.getMqttVhostPorts().block()
+        def mqttReturnValues = mqttInfo.getValue()
+
+        then: "a map with 2 mqtt ports and vhosts is returned"
+        mqttReturnValues == mqttInputMap
+
+        cleanup:
+        client.deleteMqttVhostPorts().block()
+    }
+
+    def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"(){
+        given: "a mqtt mapping with blank vhost"
+        def mqttInputMap = Map.of(2024, " ", 2025, "vhost2")
+
+        when: "client tries to set mqtt port mappings"
+        client.setMqttVhostPorts(mqttInputMap).block()
+
+        then: "an illegal argument exception is thrown"
+        thrown(IllegalArgumentException)
+    }
+
     def "GET /api/vhost-limits without limits on any host"() {
         given: "the default configuration"
 

--- a/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
+++ b/src/test/groovy/com/rabbitmq/http/client/ReactorNettyClientSpec.groovy
@@ -2459,7 +2459,7 @@ class ReactorNettyClientSpec extends Specification {
         client.deleteMqttVhostPorts().block()
     }
 
-    def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a sample mapping"(){
+    def "PUT /api/global-parameters/mqtt_port_to_vhost_mapping with a blank vhost value"(){
         given: "a mqtt mapping with blank vhost"
         def mqttInputMap = Map.of(2024, " ", 2025, "vhost2")
 


### PR DESCRIPTION
For this contribution, I followed the current setup of making the templated get function for global parameters that mirrors the vhost parameter setup. On top of that, also implemented the use of global parameter for port to virtual host mapping per specified by the rabbitmq mqtt plugin: https://www.rabbitmq.com/mqtt.html 

Not sure if there are any other global parameters that are somewhat common that should be included.