### PR TITLE
Make ParameterizedTypeReference public

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/ParameterizedTypeReference.java
+++ b/src/main/java/com/rabbitmq/http/client/ParameterizedTypeReference.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Type;
  * @param <T>
  * @since 4.0.0
  */
-abstract class ParameterizedTypeReference<T> {
+public abstract class ParameterizedTypeReference<T> {
 
   private final Type type;
 


### PR DESCRIPTION
It is necessary to implement HttpLayer.

References #511