### PR TITLE
Add null check to Page.getItemsAsList()

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/domain/Page.java
+++ b/src/main/java/com/rabbitmq/http/client/domain/Page.java
@@ -18,6 +18,7 @@ package com.rabbitmq.http.client.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class Page<T> {
@@ -63,7 +64,7 @@ public class Page<T> {
   }
 
   public List<T> getItemsAsList() {
-    return Arrays.asList(items);
+    return items != null ? Arrays.asList(items) : Collections.emptyList();
   }
 
   public int getFilteredCount() {

--- a/src/test/java/com/rabbitmq/http/client/domain/PageTest.java
+++ b/src/test/java/com/rabbitmq/http/client/domain/PageTest.java
@@ -1,0 +1,45 @@
+package com.rabbitmq.http.client.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class PageTest {
+
+  @Test
+  void itemsAsList() {
+    String[] items = new String[] { "a", "b", "c" };
+    Page<String> page = new Page<>(items);
+    List<String> itemsAsList = page.getItemsAsList();
+    assertNotNull(itemsAsList);
+    assertThat(itemsAsList).hasSize(3);
+    assertTrue(Arrays.equals(items, itemsAsList.toArray()));
+  }
+
+  @Test
+  void itemsAsListWithNullArrayReturnsEmptyList() {
+    Page<String> page = new Page<>(null);
+    List<String> itemsAsList = assertDoesNotThrow(() -> page.getItemsAsList());
+    assertNotNull(itemsAsList);
+    assertThat(itemsAsList).isEmpty();
+  }
+
+  @Test
+  void itemsAsListReturnsUnmodifiableList() {
+    String[] items = new String[] { "a", "b", "c" };
+    Page<String> page = new Page<>(items);
+    List<String> itemsAsList = page.getItemsAsList();
+    assertThrows(UnsupportedOperationException.class, () -> itemsAsList.add("d"));
+
+    page = new Page<>(null);
+    List<String> nullItemsAsList = page.getItemsAsList();
+    assertThrows(UnsupportedOperationException.class, () -> nullItemsAsList.add("a"));
+  }
+}


### PR DESCRIPTION
This PR fixes the issue described in discussion #543. `Page.items` may be null, and `Arrays.asList(items)` throws an NPE when it is. The `getItemsAsList()` method now checks to see if the array is null and returns an empty list if so.