### PR TITLE
Force percent-encoding of plus and semicolon in query parameters

### DIFF
--- a/src/main/java/com/rabbitmq/http/client/PercentEncoder.java
+++ b/src/main/java/com/rabbitmq/http/client/PercentEncoder.java
@@ -54,6 +54,14 @@ final class PercentEncoder {
     QUERY_PARAM.set('?');
     QUERY_PARAM.clear('=');
     QUERY_PARAM.clear('&');
+
+    // considered safe by RFC 3986, but need to be encoded in the wild
+    // W3C HTML 4.01 Specification (Section 17.13.4 - Form Content Types)
+    // "Space characters are replaced by '+'"
+    QUERY_PARAM.clear('+');
+    // W3C HTML 4.01 Specification (Appendix B.2.2 - Ampersands in URI attribute values):
+    // "We recommend that HTTP server implementors ... support the use of ";" in place of "&""
+    QUERY_PARAM.clear(';');
   }
 
   static String encodePathSegment(String segment) {

--- a/src/test/java/com/rabbitmq/http/client/PercentEncoderTest.java
+++ b/src/test/java/com/rabbitmq/http/client/PercentEncoderTest.java
@@ -36,7 +36,15 @@ public class PercentEncoderTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"test,test", "foobar,foobar", "foo bar,foo%20bar", "foo&bar,foo%26bar"})
+  @CsvSource({
+    "test,test",
+    "foobar,foobar",
+    "foo bar,foo%20bar",
+    "foo&bar,foo%26bar",
+    "^queue-*,%5Equeue-*",
+    "queue-+,queue-%2B",
+    "queue;test,queue%3Btest"
+  })
   void encodeParamTest(String param, String expected) {
     assertThat(PercentEncoder.encodeParameter(param)).isEqualTo(expected);
   }


### PR DESCRIPTION
Explicitly clear '+' and ';' from the allowed QUERY_PARAM safe characters.

While RFC 3986 considers these characters safe sub-delimiters within a generic URI, standard web servers and API gateways (such as HTML form parsers and Tomcat/Netty) treat them with special operational meaning:
- '+' is decoded into a space character, which breaks regex patterns.
- ';' is often interpreted as a query parameter delimiter, causing parameters to be sliced unexpectedly.

Forcing percent-encoding to '%2B' and '%3B' ensures parameter values containing these characters safely survive server-side decoding.

Fixes #661